### PR TITLE
Add AWS CloudFormation deployment assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A web application for generating and managing employee payslips, built for South
 - [Project Structure](#project-structure)
 - [Prerequisites](#prerequisites)
 - [Getting Started](#getting-started)
+- [AWS CloudFormation Deployment](#aws-cloudformation-deployment)
 - [Payment Gateway Setup](#payment-gateway-setup)
 - [Configuration](#configuration)
 - [Running Tests](#running-tests)
@@ -151,6 +152,32 @@ dotnet run
 For hosted AWS, either set both `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` explicitly or
 let the AWS SDK resolve credentials from its default chain (for example IAM roles, container
 credentials, instance metadata, `AWS_PROFILE`, or shared credentials files).
+
+### 5. Deploy to AWS with CloudFormation
+
+Payslip4All includes a repository-owned AWS deployment guide for a low-cost hosted setup using:
+
+- one EC2 instance for the web application,
+- one Application Load Balancer for public HTTPS access,
+- Route 53 aliasing for `payslip.co.za`,
+- DynamoDB persistence with hosted AWS point-in-time recovery backups.
+
+Start with:
+
+- template: `infra/aws/cloudformation/payslip4all-web.yaml`
+- operator guide: `infra/aws/cloudformation/README.md`
+
+The deployment guide keeps the operator workflow intentionally small:
+
+1. publish the application artifact,
+2. confirm ACM certificate issuance,
+3. confirm Route 53 authority for `payslip.co.za`,
+4. gather external secret references,
+5. launch the CloudFormation stack.
+
+Operators then verify deployment success using the documented signal set: `ApplicationUrl`, `InstanceId`, `LoadBalancerArn`, `InstanceSecurityGroupId`, `LoadBalancerSecurityGroupId`, `BackupProtectionMode`, ALB target health, and the public `/health` endpoint.
+
+This deployment path is designed to use as much of the AWS free tier as practical, but it is not fully free-tier-only because the ALB and Route 53 are required paid services for the requested public-domain setup.
 
 ### First-run walkthrough
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Payslip4All includes a repository-owned AWS deployment guide for a low-cost host
 
 - one EC2 instance for the web application,
 - one Application Load Balancer for public HTTPS access,
-- Route 53 aliasing for `payslip.co.za`,
+- Route 53 aliasing for `payslip4all.co.za`,
 - DynamoDB persistence with hosted AWS point-in-time recovery backups.
 
 Start with:
@@ -171,7 +171,7 @@ The deployment guide keeps the operator workflow intentionally small:
 
 1. publish the application artifact,
 2. confirm ACM certificate issuance,
-3. confirm Route 53 authority for `payslip.co.za`,
+3. confirm Route 53 authority for `payslip4all.co.za`,
 4. gather external secret references,
 5. launch the CloudFormation stack.
 

--- a/infra/aws/cloudformation/README.md
+++ b/infra/aws/cloudformation/README.md
@@ -4,9 +4,9 @@ This guide describes the repository-owned AWS deployment path for Payslip4All us
 
 ## What this deployment creates
 
-- One internet-facing Application Load Balancer for `payslip.co.za`
-- One EC2 web host tagged with payslip.co.za-derived metadata
-- One Route 53 alias record that points `payslip.co.za` to the ALB
+- One internet-facing Application Load Balancer for `payslip4all.co.za`
+- One EC2 web host tagged with payslip4all.co.za-derived metadata
+- One Route 53 alias record that points `payslip4all.co.za` to the ALB
 - One IAM instance profile so the app can use the AWS SDK credential chain
 - A DynamoDB-backed runtime with `PERSISTENCE_PROVIDER=dynamodb`
 - Automated DynamoDB point-in-time recovery for regular backups in hosted AWS
@@ -20,7 +20,7 @@ You must prepare these values before launching the stack:
 | Parameter | Why it is required |
 |-----------|--------------------|
 | `EnvironmentName` | Distinguishes production from any future non-production environment |
-| `DomainName` | Public hostname, expected to be `payslip.co.za` |
+| `DomainName` | Public hostname, expected to be `payslip4all.co.za` |
 | `HostedZoneId` | Lets Route 53 publish the ALB alias record |
 | `CertificateArn` | Enables HTTPS on the public listener through ACM |
 | `InstanceType` | Defaults to a low-cost option such as `t3.micro`, but can be overridden |
@@ -44,13 +44,13 @@ If `HostedPaymentsSecretArn` is provided, the instance also appends the secret v
 
 ## Architecture and traffic flow
 
-1. Route 53 publishes `payslip.co.za` as an alias to the Application Load Balancer.
+1. Route 53 publishes `payslip4all.co.za` as an alias to the Application Load Balancer.
 2. The ALB terminates TLS with ACM and redirects HTTP traffic to HTTPS.
 3. The ALB forwards only healthy requests to the EC2 instance on port 80.
 4. Payslip4All responds to the ALB health check at `/health`.
 5. The web app starts with `PERSISTENCE_PROVIDER=dynamodb`, then provisions and uses the application-owned DynamoDB tables.
 
-The EC2 instance uses a payslip.co.za-derived `Name` tag such as `payslip-co-za-web-prod`. The public domain belongs to the ALB only; the instance is identified operationally through tags and instance IDs rather than a second public DNS record.
+The EC2 instance uses a payslip4all.co.za-derived `Name` tag such as `payslip4all-co-za-web-prod`. The public domain belongs to the ALB only; the instance is identified operationally through tags and instance IDs rather than a second public DNS record.
 
 ## Operator-visible signals
 
@@ -59,15 +59,15 @@ Operators should verify the deployment with this explicit signal set:
 - CloudFormation outputs: `ApplicationUrl`, `InstanceId`, `LoadBalancerArn`, `InstanceSecurityGroupId`, `LoadBalancerSecurityGroupId`, `HostedPaymentsSecretReference`, `BackupProtectionMode`, and `RestoreRunbook`
 - ALB target health for the registered EC2 instance
 - The public `/health` endpoint
-- The payslip.co.za-derived `Name` tags on the ALB and EC2 instance
+- The payslip4all.co.za-derived `Name` tags on the ALB and EC2 instance
 
 These signals are intentionally minimal: enough to verify stack identity, app reachability, network wiring, and backup posture without turning this feature into a separate observability project.
 
 ## Five manual pre-launch actions
 
 1. Publish or upload the application artifact that `ArtifactSource` will reference.
-2. Confirm the ACM certificate for `payslip.co.za` is issued in the target AWS region.
-3. Confirm the Route 53 hosted zone is authoritative for `payslip.co.za`.
+2. Confirm the ACM certificate for `payslip4all.co.za` is issued in the target AWS region.
+3. Confirm the Route 53 hosted zone is authoritative for `payslip4all.co.za`.
 4. Gather the external secret references required for hosted-payment and application runtime configuration.
 5. Launch `infra/aws/cloudformation/payslip4all-web.yaml` with the required parameters.
 
@@ -76,7 +76,7 @@ These five actions are the complete manual pre-launch workflow for this feature.
 ## Post-launch verification
 
 1. Wait for the stack to complete.
-2. Open `https://payslip.co.za`.
+2. Open `https://payslip4all.co.za`.
 3. Confirm the ALB returns the app and the EC2 instance is tagged for the same environment.
 4. Inspect ALB target health and confirm the registered instance is healthy.
 5. Call `/health` and confirm the application returns a healthy response.
@@ -119,7 +119,7 @@ The hosted AWS deployment enables **point-in-time recovery** by default so the P
 2. Restore each required table to a new table name from the desired recovery point so every restore goes to a new table rather than the live one.
 3. Validate the restored data before any cutover.
 4. If a cutover is required, update the application's table prefix or restore mapping in a controlled maintenance window.
-5. Re-run application verification and confirm `https://payslip.co.za` still serves correctly after the data recovery workflow.
+5. Re-run application verification and confirm `https://payslip4all.co.za` still serves correctly after the data recovery workflow.
 
 Aim to complete the restore drill, including validation, within the feature's 60-minute recovery target.
 
@@ -127,9 +127,9 @@ Aim to complete the restore drill, including validation, within the feature's 60
 
 After launch:
 
-1. Browse to `https://payslip.co.za`.
+1. Browse to `https://payslip4all.co.za`.
 2. Confirm HTTP requests are redirected to HTTPS.
 3. Confirm `/health` returns a healthy response through the stack.
-4. Confirm the EC2 instance is tagged with a payslip.co.za-derived name.
+4. Confirm the EC2 instance is tagged with a payslip4all.co.za-derived name.
 5. Confirm the app starts with `PERSISTENCE_PROVIDER=dynamodb`, `DYNAMODB_REGION`, and `DYNAMODB_TABLE_PREFIX`.
 6. Confirm the hosted AWS environment reports point-in-time recovery enabled for the Payslip4All tables.

--- a/infra/aws/cloudformation/README.md
+++ b/infra/aws/cloudformation/README.md
@@ -1,0 +1,135 @@
+# AWS CloudFormation Deployment
+
+This guide describes the repository-owned AWS deployment path for Payslip4All using a single EC2 instance, an Application Load Balancer, Route 53, and DynamoDB.
+
+## What this deployment creates
+
+- One internet-facing Application Load Balancer for `payslip.co.za`
+- One EC2 web host tagged with payslip.co.za-derived metadata
+- One Route 53 alias record that points `payslip.co.za` to the ALB
+- One IAM instance profile so the app can use the AWS SDK credential chain
+- A DynamoDB-backed runtime with `PERSISTENCE_PROVIDER=dynamodb`
+- Automated DynamoDB point-in-time recovery for regular backups in hosted AWS
+
+The CloudFormation template lives at `infra/aws/cloudformation/payslip4all-web.yaml`. The bootstrap logic mirrored by the stack user data lives at `infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh`.
+
+## Prerequisites
+
+You must prepare these values before launching the stack:
+
+| Parameter | Why it is required |
+|-----------|--------------------|
+| `EnvironmentName` | Distinguishes production from any future non-production environment |
+| `DomainName` | Public hostname, expected to be `payslip.co.za` |
+| `HostedZoneId` | Lets Route 53 publish the ALB alias record |
+| `CertificateArn` | Enables HTTPS on the public listener through ACM |
+| `InstanceType` | Defaults to a low-cost option such as `t3.micro`, but can be overridden |
+| `ArtifactSource` | Points the bootstrap process at the published Payslip4All bundle |
+| `AllowedSshCidr` | Restricts operator shell access to approved IP ranges |
+| `DynamoDbRegion` | Required by the application's DynamoDB startup validation |
+| `DynamoDbTablePrefix` | Namespaces the application-owned table set |
+| `HostedPaymentsSecretArn` | Optional secret reference for hosted-payment and app-specific configuration |
+
+## Runtime environment variables
+
+The EC2 bootstrap process writes these values into the service environment:
+
+- `PERSISTENCE_PROVIDER=dynamodb`
+- `DYNAMODB_REGION`
+- `DYNAMODB_TABLE_PREFIX`
+- `DYNAMODB_ENABLE_PITR`
+- `ASPNETCORE_URLS=http://0.0.0.0:80`
+
+If `HostedPaymentsSecretArn` is provided, the instance also appends the secret values to the app environment file using AWS Secrets Manager. Keep reusable secrets out of the template itself.
+
+## Architecture and traffic flow
+
+1. Route 53 publishes `payslip.co.za` as an alias to the Application Load Balancer.
+2. The ALB terminates TLS with ACM and redirects HTTP traffic to HTTPS.
+3. The ALB forwards only healthy requests to the EC2 instance on port 80.
+4. Payslip4All responds to the ALB health check at `/health`.
+5. The web app starts with `PERSISTENCE_PROVIDER=dynamodb`, then provisions and uses the application-owned DynamoDB tables.
+
+The EC2 instance uses a payslip.co.za-derived `Name` tag such as `payslip-co-za-web-prod`. The public domain belongs to the ALB only; the instance is identified operationally through tags and instance IDs rather than a second public DNS record.
+
+## Operator-visible signals
+
+Operators should verify the deployment with this explicit signal set:
+
+- CloudFormation outputs: `ApplicationUrl`, `InstanceId`, `LoadBalancerArn`, `InstanceSecurityGroupId`, `LoadBalancerSecurityGroupId`, `HostedPaymentsSecretReference`, `BackupProtectionMode`, and `RestoreRunbook`
+- ALB target health for the registered EC2 instance
+- The public `/health` endpoint
+- The payslip.co.za-derived `Name` tags on the ALB and EC2 instance
+
+These signals are intentionally minimal: enough to verify stack identity, app reachability, network wiring, and backup posture without turning this feature into a separate observability project.
+
+## Five manual pre-launch actions
+
+1. Publish or upload the application artifact that `ArtifactSource` will reference.
+2. Confirm the ACM certificate for `payslip.co.za` is issued in the target AWS region.
+3. Confirm the Route 53 hosted zone is authoritative for `payslip.co.za`.
+4. Gather the external secret references required for hosted-payment and application runtime configuration.
+5. Launch `infra/aws/cloudformation/payslip4all-web.yaml` with the required parameters.
+
+These five actions are the complete manual pre-launch workflow for this feature.
+
+## Post-launch verification
+
+1. Wait for the stack to complete.
+2. Open `https://payslip.co.za`.
+3. Confirm the ALB returns the app and the EC2 instance is tagged for the same environment.
+4. Inspect ALB target health and confirm the registered instance is healthy.
+5. Call `/health` and confirm the application returns a healthy response.
+
+## Free-tier and cost notes
+
+This deployment is optimized for low cost, but it is **not fully free tier** because the required edge services are billable.
+
+- The template defaults to a small EC2 instance type to use as much of the free tier as practical.
+- DynamoDB uses the app's on-demand table model, which is cost-efficient for low traffic.
+- **Application Load Balancer (ALB)** is a recurring cost outside the free tier.
+- **Route 53** hosted zones and DNS queries are also outside the free tier.
+- ACM certificates are not the primary cost concern here; the paid pieces are the ALB, Route 53, and any DynamoDB traffic or backup storage above the free tier.
+
+## Health checks and startup validation
+
+- The ALB target group probes `/health`.
+- The app trusts forwarded headers and redirects to HTTPS correctly when fronted by the ALB.
+- The web app enables request logging so behind-ALB traffic is visible in structured application logs.
+- Startup fails fast if `DYNAMODB_REGION` is missing or if only one of `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` is supplied.
+- The preferred hosted AWS path uses the IAM instance profile, not static AWS credentials.
+
+## Replaceable compute behaviour
+
+The CloudFormation stack keeps networking, DNS, ALB resources, and DynamoDB-backed application data independent of the EC2 instance lifecycle. Updating the stack and replacing or recreating the EC2 instance should therefore keep application data available and ensure the public entry point remains the same, assuming the replacement instance boots successfully and rejoins the target group.
+
+## DynamoDB backup and restore
+
+The hosted AWS deployment enables **point-in-time recovery** by default so the Payslip4All table set is regularly backed up without daily manual jobs.
+
+- `DYNAMODB_ENABLE_PITR=true` keeps backup protection on in hosted AWS.
+- If `DYNAMODB_ENDPOINT` is set for a local emulator, the backup-protection hosted service skips PITR configuration.
+- Restores should target new DynamoDB tables first so recovery does not overwrite the live environment in place.
+- The recommended non-live naming pattern is `{live-table-name}-restore-YYYYMMDDHHMMSS`.
+- Always restore to a new table before considering any cutover.
+
+### Restore runbook
+
+1. Identify the affected table set for the current `DYNAMODB_TABLE_PREFIX`.
+2. Restore each required table to a new table name from the desired recovery point so every restore goes to a new table rather than the live one.
+3. Validate the restored data before any cutover.
+4. If a cutover is required, update the application's table prefix or restore mapping in a controlled maintenance window.
+5. Re-run application verification and confirm `https://payslip.co.za` still serves correctly after the data recovery workflow.
+
+Aim to complete the restore drill, including validation, within the feature's 60-minute recovery target.
+
+## Recommended verification
+
+After launch:
+
+1. Browse to `https://payslip.co.za`.
+2. Confirm HTTP requests are redirected to HTTPS.
+3. Confirm `/health` returns a healthy response through the stack.
+4. Confirm the EC2 instance is tagged with a payslip.co.za-derived name.
+5. Confirm the app starts with `PERSISTENCE_PROVIDER=dynamodb`, `DYNAMODB_REGION`, and `DYNAMODB_TABLE_PREFIX`.
+6. Confirm the hosted AWS environment reports point-in-time recovery enabled for the Payslip4All tables.

--- a/infra/aws/cloudformation/payslip4all-web.yaml
+++ b/infra/aws/cloudformation/payslip4all-web.yaml
@@ -8,7 +8,7 @@ Parameters:
     Description: Environment identifier used in resource names and tags.
   DomainName:
     Type: String
-    Default: payslip.co.za
+    Default: payslip4all.co.za
     Description: Public application hostname.
   HostedZoneId:
     Type: String
@@ -55,14 +55,14 @@ Resources:
       EnableDnsHostnames: true
       Tags:
         - Key: Name
-          Value: !Sub payslip-co-za-vpc-${EnvironmentName}
+          Value: !Sub payslip4all-co-za-vpc-${EnvironmentName}
 
   InternetGateway:
     Type: AWS::EC2::InternetGateway
     Properties:
       Tags:
         - Key: Name
-          Value: !Sub payslip-co-za-igw-${EnvironmentName}
+          Value: !Sub payslip4all-co-za-igw-${EnvironmentName}
 
   VpcGatewayAttachment:
     Type: AWS::EC2::VPCGatewayAttachment
@@ -79,7 +79,7 @@ Resources:
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
-          Value: !Sub payslip-co-za-public-a-${EnvironmentName}
+          Value: !Sub payslip4all-co-za-public-a-${EnvironmentName}
 
   PublicSubnetB:
     Type: AWS::EC2::Subnet
@@ -90,7 +90,7 @@ Resources:
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
-          Value: !Sub payslip-co-za-public-b-${EnvironmentName}
+          Value: !Sub payslip4all-co-za-public-b-${EnvironmentName}
 
   PublicRouteTable:
     Type: AWS::EC2::RouteTable
@@ -98,7 +98,7 @@ Resources:
       VpcId: !Ref PublicVpc
       Tags:
         - Key: Name
-          Value: !Sub payslip-co-za-public-rt-${EnvironmentName}
+          Value: !Sub payslip4all-co-za-public-rt-${EnvironmentName}
 
   DefaultRoute:
     Type: AWS::EC2::Route
@@ -139,7 +139,7 @@ Resources:
           CidrIp: 0.0.0.0/0
       Tags:
         - Key: Name
-          Value: !Sub payslip-co-za-alb-sg-${EnvironmentName}
+          Value: !Sub payslip4all-co-za-alb-sg-${EnvironmentName}
 
   InstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -160,7 +160,7 @@ Resources:
           CidrIp: 0.0.0.0/0
       Tags:
         - Key: Name
-          Value: !Sub payslip-co-za-web-sg-${EnvironmentName}
+          Value: !Sub payslip4all-co-za-web-sg-${EnvironmentName}
 
   AppInstanceRole:
     Type: AWS::IAM::Role
@@ -210,7 +210,7 @@ Resources:
                 - !Ref AWS::NoValue
       Tags:
         - Key: Name
-          Value: !Sub payslip-co-za-web-role-${EnvironmentName}
+          Value: !Sub payslip4all-co-za-web-role-${EnvironmentName}
 
   AppInstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -221,7 +221,7 @@ Resources:
   ApplicationLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
-      Name: !Sub payslip-co-za-alb-${EnvironmentName}
+      Name: !Sub payslip4all-co-za-alb-${EnvironmentName}
       Scheme: internet-facing
       Type: application
       SecurityGroups:
@@ -231,7 +231,7 @@ Resources:
         - !Ref PublicSubnetB
       Tags:
         - Key: Name
-          Value: !Sub payslip-co-za-alb-${EnvironmentName}
+          Value: !Sub payslip4all-co-za-alb-${EnvironmentName}
 
   ApplicationTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
@@ -250,7 +250,7 @@ Resources:
           Port: 80
       Tags:
         - Key: Name
-          Value: !Sub payslip-co-za-targets-${EnvironmentName}
+          Value: !Sub payslip4all-co-za-targets-${EnvironmentName}
 
   HttpListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
@@ -346,7 +346,7 @@ Resources:
           systemctl restart payslip4all.service
       Tags:
         - Key: Name
-          Value: !Sub payslip-co-za-web-${EnvironmentName}
+          Value: !Sub payslip4all-co-za-web-${EnvironmentName}
         - Key: Domain
           Value: !Ref DomainName
 

--- a/infra/aws/cloudformation/payslip4all-web.yaml
+++ b/infra/aws/cloudformation/payslip4all-web.yaml
@@ -1,0 +1,394 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Deploy Payslip4All to AWS on a single EC2 instance behind an ALB with DynamoDB persistence.
+
+Parameters:
+  EnvironmentName:
+    Type: String
+    Default: prod
+    Description: Environment identifier used in resource names and tags.
+  DomainName:
+    Type: String
+    Default: payslip.co.za
+    Description: Public application hostname.
+  HostedZoneId:
+    Type: String
+    Description: Route 53 hosted zone ID that serves the public hostname.
+  CertificateArn:
+    Type: String
+    Description: ACM certificate ARN for the public hostname.
+  InstanceType:
+    Type: String
+    Default: t3.micro
+    Description: Low-cost default instance type; override only when required.
+  ArtifactSource:
+    Type: String
+    Description: HTTPS or S3-backed artifact URL for the published Payslip4All deployment bundle.
+  AllowedSshCidr:
+    Type: String
+    Default: 0.0.0.0/32
+    Description: Operator CIDR allowed to reach the instance by SSH.
+  DynamoDbRegion:
+    Type: String
+    Description: Runtime AWS region used by the DynamoDB provider.
+  DynamoDbTablePrefix:
+    Type: String
+    Default: payslip4all
+    Description: Prefix used by the application-owned DynamoDB tables.
+  HostedPaymentsSecretArn:
+    Type: String
+    Default: ''
+    Description: Optional Secrets Manager ARN that stores hosted-payment and app secrets.
+  EnablePointInTimeRecovery:
+    Type: String
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'true'
+    Description: Leave true in hosted AWS to enable regular DynamoDB backups through PITR.
+
+Resources:
+  PublicVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.42.0.0/16
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: !Sub payslip-co-za-vpc-${EnvironmentName}
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub payslip-co-za-igw-${EnvironmentName}
+
+  VpcGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref PublicVpc
+      InternetGatewayId: !Ref InternetGateway
+
+  PublicSubnetA:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref PublicVpc
+      AvailabilityZone: !Select [0, !GetAZs '']
+      CidrBlock: 10.42.0.0/24
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub payslip-co-za-public-a-${EnvironmentName}
+
+  PublicSubnetB:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref PublicVpc
+      AvailabilityZone: !Select [1, !GetAZs '']
+      CidrBlock: 10.42.1.0/24
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub payslip-co-za-public-b-${EnvironmentName}
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref PublicVpc
+      Tags:
+        - Key: Name
+          Value: !Sub payslip-co-za-public-rt-${EnvironmentName}
+
+  DefaultRoute:
+    Type: AWS::EC2::Route
+    DependsOn: VpcGatewayAttachment
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnetARouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnetA
+
+  PublicSubnetBRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnetB
+
+  LoadBalancerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Public ingress for the Payslip4All Application Load Balancer.
+      VpcId: !Ref PublicVpc
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Name
+          Value: !Sub payslip-co-za-alb-sg-${EnvironmentName}
+
+  InstanceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: EC2 ingress restricted to the ALB and operator SSH range.
+      VpcId: !Ref PublicVpc
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: !Ref AllowedSshCidr
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Name
+          Value: !Sub payslip-co-za-web-sg-${EnvironmentName}
+
+  AppInstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: !Sub payslip4all-web-${EnvironmentName}
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:BatchWriteItem
+                  - dynamodb:CreateTable
+                  - dynamodb:DeleteItem
+                  - dynamodb:DescribeContinuousBackups
+                  - dynamodb:DescribeTable
+                  - dynamodb:GetItem
+                  - dynamodb:ListTables
+                  - dynamodb:PutItem
+                  - dynamodb:Query
+                  - dynamodb:RestoreTableToPointInTime
+                  - dynamodb:Scan
+                  - dynamodb:UpdateContinuousBackups
+                  - dynamodb:UpdateItem
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: '*'
+              - !If
+                - HasHostedPaymentsSecret
+                - Effect: Allow
+                  Action:
+                    - secretsmanager:GetSecretValue
+                  Resource: !Ref HostedPaymentsSecretArn
+                - !Ref AWS::NoValue
+      Tags:
+        - Key: Name
+          Value: !Sub payslip-co-za-web-role-${EnvironmentName}
+
+  AppInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+        - !Ref AppInstanceRole
+
+  ApplicationLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: !Sub payslip-co-za-alb-${EnvironmentName}
+      Scheme: internet-facing
+      Type: application
+      SecurityGroups:
+        - !Ref LoadBalancerSecurityGroup
+      Subnets:
+        - !Ref PublicSubnetA
+        - !Ref PublicSubnetB
+      Tags:
+        - Key: Name
+          Value: !Sub payslip-co-za-alb-${EnvironmentName}
+
+  ApplicationTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub p4a-web-${EnvironmentName}
+      Port: 80
+      Protocol: HTTP
+      TargetType: instance
+      VpcId: !Ref PublicVpc
+      HealthCheckEnabled: true
+      HealthCheckPath: /health
+      Matcher:
+        HttpCode: 200
+      Targets:
+        - Id: !Ref WebInstance
+          Port: 80
+      Tags:
+        - Key: Name
+          Value: !Sub payslip-co-za-targets-${EnvironmentName}
+
+  HttpListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref ApplicationLoadBalancer
+      Port: 80
+      Protocol: HTTP
+      DefaultActions:
+        - Type: redirect
+          RedirectConfig:
+            Protocol: HTTPS
+            Port: '443'
+            Host: '#{host}'
+            Path: '/#{path}'
+            Query: '#{query}'
+            StatusCode: HTTP_301
+
+  HttpsListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref ApplicationLoadBalancer
+      Port: 443
+      Protocol: HTTPS
+      Certificates:
+        - CertificateArn: !Ref CertificateArn
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref ApplicationTargetGroup
+
+  WebInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64}}'
+      InstanceType: !Ref InstanceType
+      IamInstanceProfile: !Ref AppInstanceProfile
+      NetworkInterfaces:
+        - AssociatePublicIpAddress: true
+          DeviceIndex: '0'
+          GroupSet:
+            - !Ref InstanceSecurityGroup
+          SubnetId: !Ref PublicSubnetA
+      MetadataOptions:
+        HttpTokens: required
+      UserData:
+        Fn::Base64: !Sub |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          APP_ROOT="/opt/payslip4all"
+          APP_USER="payslip4all"
+          ENV_DIR="/etc/payslip4all"
+          ENV_FILE="${ENV_DIR}/payslip4all.env"
+          SERVICE_FILE="/etc/systemd/system/payslip4all.service"
+          dnf install -y curl tar gzip jq awscli aspnetcore-runtime-8.0
+          if ! id "${APP_USER}" >/dev/null 2>&1; then
+            useradd --system --home "${APP_ROOT}" --shell /sbin/nologin "${APP_USER}"
+          fi
+          mkdir -p "${APP_ROOT}" "${ENV_DIR}"
+          curl --fail --location --silent --show-error "${ArtifactSource}" --output /tmp/payslip4all.tgz
+          rm -rf "${APP_ROOT:?}/"*
+          tar -xzf /tmp/payslip4all.tgz -C "${APP_ROOT}"
+          cat > "${ENV_FILE}" <<EOF
+          ASPNETCORE_ENVIRONMENT=Production
+          ASPNETCORE_URLS=http://0.0.0.0:80
+          PERSISTENCE_PROVIDER=dynamodb
+          DYNAMODB_REGION=${DynamoDbRegion}
+          DYNAMODB_TABLE_PREFIX=${DynamoDbTablePrefix}
+          DYNAMODB_ENABLE_PITR=${EnablePointInTimeRecovery}
+          EOF
+          if [[ -n "${HostedPaymentsSecretArn}" ]]; then
+            aws secretsmanager get-secret-value --secret-id "${HostedPaymentsSecretArn}" --query SecretString --output text | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "${ENV_FILE}"
+          fi
+          cat > "${SERVICE_FILE}" <<EOF
+          [Unit]
+          Description=Payslip4All web application
+          After=network-online.target
+          Wants=network-online.target
+
+          [Service]
+          Type=simple
+          User=${APP_USER}
+          WorkingDirectory=${APP_ROOT}
+          EnvironmentFile=${ENV_FILE}
+          ExecStart=/usr/bin/dotnet ${APP_ROOT}/Payslip4All.Web.dll
+          Restart=always
+          RestartSec=5
+
+          [Install]
+          WantedBy=multi-user.target
+          EOF
+          chown -R "${APP_USER}:${APP_USER}" "${APP_ROOT}" "${ENV_DIR}"
+          systemctl daemon-reload
+          systemctl enable payslip4all.service
+          systemctl restart payslip4all.service
+      Tags:
+        - Key: Name
+          Value: !Sub payslip-co-za-web-${EnvironmentName}
+        - Key: Domain
+          Value: !Ref DomainName
+
+  PublicDnsRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Ref DomainName
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt ApplicationLoadBalancer.DNSName
+        HostedZoneId: !GetAtt ApplicationLoadBalancer.CanonicalHostedZoneID
+        EvaluateTargetHealth: true
+
+Conditions:
+  HasHostedPaymentsSecret: !Not [!Equals [!Ref HostedPaymentsSecretArn, '']]
+
+Outputs:
+  ApplicationUrl:
+    Description: Public HTTPS URL for Payslip4All.
+    Value: !Sub https://${DomainName}
+  InstanceId:
+    Description: The EC2 instance serving Payslip4All.
+    Value: !Ref WebInstance
+  LoadBalancerArn:
+    Description: ARN of the public Application Load Balancer.
+    Value: !Ref ApplicationLoadBalancer
+  InstanceSecurityGroupId:
+    Description: EC2 security group for operator troubleshooting.
+    Value: !Ref InstanceSecurityGroup
+  LoadBalancerSecurityGroupId:
+    Description: ALB security group for troubleshooting load balancer ingress.
+    Value: !Ref LoadBalancerSecurityGroup
+  HostedPaymentsSecretReference:
+    Description: Secret reference used for hosted-payment and runtime app configuration updates.
+    Value: !If
+      - HasHostedPaymentsSecret
+      - !Ref HostedPaymentsSecretArn
+      - no-external-secret-configured
+  BackupProtectionMode:
+    Description: DynamoDB backup protection mode for hosted AWS.
+    Value: point-in-time recovery via hosted service
+  RestoreRunbook:
+    Description: Operator restore reference.
+    Value: infra/aws/cloudformation/README.md#dynamodb-backup-and-restore

--- a/infra/aws/cloudformation/payslip4all-web.yaml
+++ b/infra/aws/cloudformation/payslip4all-web.yaml
@@ -181,6 +181,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                  - cloudformation:SignalResource
                   - dynamodb:BatchWriteItem
                   - dynamodb:CreateTable
                   - dynamodb:DeleteItem
@@ -245,9 +246,6 @@ Resources:
       HealthCheckPath: /health
       Matcher:
         HttpCode: 200
-      Targets:
-        - Id: !Ref WebInstance
-          Port: 80
       Tags:
         - Key: Name
           Value: !Sub payslip4all-co-za-targets-${EnvironmentName}
@@ -274,6 +272,7 @@ Resources:
       LoadBalancerArn: !Ref ApplicationLoadBalancer
       Port: 443
       Protocol: HTTPS
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
       Certificates:
         - CertificateArn: !Ref CertificateArn
       DefaultActions:
@@ -282,6 +281,10 @@ Resources:
 
   WebInstance:
     Type: AWS::EC2::Instance
+    CreationPolicy:
+      ResourceSignal:
+        Count: 1
+        Timeout: PT15M
     Properties:
       ImageId: '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64}}'
       InstanceType: !Ref InstanceType
@@ -307,7 +310,13 @@ Resources:
           if ! id "${APP_USER}" >/dev/null 2>&1; then
             useradd --system --home "${APP_ROOT}" --shell /sbin/nologin "${APP_USER}"
           fi
+          signal_failure() {
+            local reason="${1:-bootstrap failed}"
+            aws cloudformation signal-resource --stack-name "${AWS::StackName}" --logical-resource-id WebInstance --status FAILURE --reason "${reason}" --unique-id "${HOSTNAME:-webinstance}" --region "${AWS::Region}" || true
+          }
+          trap 'signal_failure "bootstrap failed at line ${LINENO}"' ERR
           mkdir -p "${APP_ROOT}" "${ENV_DIR}"
+          install -m 0600 /dev/null "${ENV_FILE}"
           curl --fail --location --silent --show-error "${ArtifactSource}" --output /tmp/payslip4all.tgz
           rm -rf "${APP_ROOT:?}/"*
           tar -xzf /tmp/payslip4all.tgz -C "${APP_ROOT}"
@@ -319,6 +328,7 @@ Resources:
           DYNAMODB_TABLE_PREFIX=${DynamoDbTablePrefix}
           DYNAMODB_ENABLE_PITR=${EnablePointInTimeRecovery}
           EOF
+          chmod 600 "${ENV_FILE}"
           if [[ -n "${HostedPaymentsSecretArn}" ]]; then
             aws secretsmanager get-secret-value --secret-id "${HostedPaymentsSecretArn}" --query SecretString --output text | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "${ENV_FILE}"
           fi
@@ -344,11 +354,28 @@ Resources:
           systemctl daemon-reload
           systemctl enable payslip4all.service
           systemctl restart payslip4all.service
+          for attempt in $(seq 1 12); do
+            if systemctl is-active --quiet payslip4all.service && curl --fail --silent http://127.0.0.1/health >/dev/null; then
+              aws cloudformation signal-resource --stack-name "${AWS::StackName}" --logical-resource-id WebInstance --status SUCCESS --unique-id "${HOSTNAME:-webinstance}" --region "${AWS::Region}"
+              trap - ERR
+              exit 0
+            fi
+            sleep 5
+          done
+          signal_failure "payslip4all.service did not become healthy in time"
+          exit 1
       Tags:
         - Key: Name
           Value: !Sub payslip4all-co-za-web-${EnvironmentName}
         - Key: Domain
           Value: !Ref DomainName
+
+  WebInstanceTargetAttachment:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroupAttachment
+    Properties:
+      TargetGroupArn: !Ref ApplicationTargetGroup
+      TargetId: !Ref WebInstance
+      Port: 80
 
   PublicDnsRecord:
     Type: AWS::Route53::RecordSet

--- a/infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh
+++ b/infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="/opt/payslip4all"
+APP_USER="payslip4all"
+ENV_DIR="/etc/payslip4all"
+ENV_FILE="${ENV_DIR}/payslip4all.env"
+SERVICE_FILE="/etc/systemd/system/payslip4all.service"
+
+ARTIFACT_SOURCE="${ARTIFACT_SOURCE:?ARTIFACT_SOURCE is required}"
+ASPNETCORE_ENVIRONMENT="${ASPNETCORE_ENVIRONMENT:-Production}"
+PERSISTENCE_PROVIDER="${PERSISTENCE_PROVIDER:-dynamodb}"
+DYNAMODB_REGION="${DYNAMODB_REGION:?DYNAMODB_REGION is required}"
+DYNAMODB_TABLE_PREFIX="${DYNAMODB_TABLE_PREFIX:-payslip4all}"
+DYNAMODB_ENABLE_PITR="${DYNAMODB_ENABLE_PITR:-true}"
+HOSTED_PAYMENTS_SECRET_ARN="${HOSTED_PAYMENTS_SECRET_ARN:-}"
+
+if ! id "${APP_USER}" >/dev/null 2>&1; then
+  useradd --system --home "${APP_ROOT}" --shell /sbin/nologin "${APP_USER}"
+fi
+
+dnf install -y curl tar gzip jq awscli aspnetcore-runtime-8.0
+
+mkdir -p "${APP_ROOT}" "${ENV_DIR}"
+curl --fail --location --silent --show-error "${ARTIFACT_SOURCE}" --output /tmp/payslip4all.tgz
+rm -rf "${APP_ROOT:?}/"*
+tar -xzf /tmp/payslip4all.tgz -C "${APP_ROOT}"
+
+cat > "${ENV_FILE}" <<EOF
+ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT}
+ASPNETCORE_URLS=http://0.0.0.0:80
+PERSISTENCE_PROVIDER=${PERSISTENCE_PROVIDER}
+DYNAMODB_REGION=${DYNAMODB_REGION}
+DYNAMODB_TABLE_PREFIX=${DYNAMODB_TABLE_PREFIX}
+DYNAMODB_ENABLE_PITR=${DYNAMODB_ENABLE_PITR}
+EOF
+
+if [[ -n "${HOSTED_PAYMENTS_SECRET_ARN}" ]]; then
+  aws secretsmanager get-secret-value \
+    --secret-id "${HOSTED_PAYMENTS_SECRET_ARN}" \
+    --query SecretString \
+    --output text | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "${ENV_FILE}"
+fi
+
+chown -R "${APP_USER}:${APP_USER}" "${APP_ROOT}" "${ENV_DIR}"
+
+cat > "${SERVICE_FILE}" <<EOF
+[Unit]
+Description=Payslip4All web application
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=${APP_USER}
+WorkingDirectory=${APP_ROOT}
+EnvironmentFile=${ENV_FILE}
+ExecStart=/usr/bin/dotnet ${APP_ROOT}/Payslip4All.Web.dll
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable payslip4all.service
+systemctl restart payslip4all.service

--- a/infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh
+++ b/infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh
@@ -22,6 +22,7 @@ fi
 dnf install -y curl tar gzip jq awscli aspnetcore-runtime-8.0
 
 mkdir -p "${APP_ROOT}" "${ENV_DIR}"
+install -m 0600 /dev/null "${ENV_FILE}"
 curl --fail --location --silent --show-error "${ARTIFACT_SOURCE}" --output /tmp/payslip4all.tgz
 rm -rf "${APP_ROOT:?}/"*
 tar -xzf /tmp/payslip4all.tgz -C "${APP_ROOT}"
@@ -34,6 +35,8 @@ DYNAMODB_REGION=${DYNAMODB_REGION}
 DYNAMODB_TABLE_PREFIX=${DYNAMODB_TABLE_PREFIX}
 DYNAMODB_ENABLE_PITR=${DYNAMODB_ENABLE_PITR}
 EOF
+
+chmod 600 "${ENV_FILE}"
 
 if [[ -n "${HOSTED_PAYMENTS_SECRET_ARN}" ]]; then
   aws secretsmanager get-secret-value \

--- a/specs/011-aws-cloudformation/checklists/requirements.md
+++ b/specs/011-aws-cloudformation/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: AWS CloudFormation Deployment
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-07  
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation refreshed on 2026-04-07 against `spec.md`; no clarification markers remain.
+- The spec now distinguishes the MVP deployment slice from the later public-domain publishing slice, explicitly defines the externalized input categories, clarifies the required deployment signals, and aligns SC-005 with the documented five-action operator workflow.

--- a/specs/011-aws-cloudformation/contracts/cloudformation-deployment-contract.md
+++ b/specs/011-aws-cloudformation/contracts/cloudformation-deployment-contract.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Define the operator-facing contract for the AWS CloudFormation assets that deploy Payslip4All on EC2 with DynamoDB persistence and a public `payslip.co.za` entry point.
+Define the operator-facing contract for the AWS CloudFormation assets that deploy Payslip4All on EC2 with DynamoDB persistence and a public `payslip4all.co.za` entry point.
 
 ## Audience
 
@@ -20,7 +20,7 @@ The CloudFormation assets MUST accept or document operator-supplied values for:
 | Input | Purpose |
 |-------|---------|
 | `EnvironmentName` | Distinguishes environments such as production or staging |
-| `DomainName` | Public application hostname, expected to be `payslip.co.za` for the target environment |
+| `DomainName` | Public application hostname, expected to be `payslip4all.co.za` for the target environment |
 | `HostedZoneId` or equivalent DNS prerequisite | Allows the public hostname to resolve to the load balancer |
 | `CertificateArn` | Enables HTTPS on the public entry point |
 | `InstanceType` | Allows low-cost default compute with explicit override when needed |
@@ -35,13 +35,13 @@ The CloudFormation assets MUST accept or document operator-supplied values for:
 The CloudFormation assets MUST:
 
 1. create one EC2-based Payslip4All web host,
-2. create an internet-facing load-balanced entry point for `payslip.co.za`,
+2. create an internet-facing load-balanced entry point for `payslip4all.co.za`,
 3. enforce secure HTTPS access and redirect insecure HTTP traffic,
 4. route application traffic to the EC2 instance only when health checks pass,
 5. configure the app to run with `PERSISTENCE_PROVIDER=dynamodb`,
 6. provide `DYNAMODB_REGION` and `DYNAMODB_TABLE_PREFIX` to the running app,
 7. prefer IAM-based AWS access from the instance over embedded static AWS credentials,
-8. identify the EC2 instance with payslip.co.za-derived metadata,
+8. identify the EC2 instance with payslip4all.co.za-derived metadata,
 9. avoid provisioning unnecessary paid services when a lower-cost supported alternative exists,
 10. enable automated DynamoDB recovery protection suitable for regular backups.
 
@@ -96,7 +96,7 @@ The deployment documentation MUST keep the manual pre-launch workflow to no more
 
 1. publish the application artifact,
 2. confirm ACM certificate issuance,
-3. confirm Route 53 authority for `payslip.co.za`,
+3. confirm Route 53 authority for `payslip4all.co.za`,
 4. gather external secret references,
 5. launch the CloudFormation stack with parameters.
 
@@ -105,7 +105,7 @@ The deployment documentation MUST keep the manual pre-launch workflow to no more
 This contract is satisfied when:
 
 1. An operator can deploy Payslip4All to AWS through one CloudFormation-driven workflow.
-2. End users reach the app at `https://payslip.co.za` rather than through the EC2 instance directly.
+2. End users reach the app at `https://payslip4all.co.za` rather than through the EC2 instance directly.
 3. The running app boots successfully using the existing DynamoDB provider path and environment variables.
 4. Replacing the EC2 instance does not discard DynamoDB-backed application data.
 5. The deployment provides an operator-verifiable automated DynamoDB recovery path.

--- a/specs/011-aws-cloudformation/contracts/cloudformation-deployment-contract.md
+++ b/specs/011-aws-cloudformation/contracts/cloudformation-deployment-contract.md
@@ -1,0 +1,113 @@
+# Contract: CloudFormation Deployment
+
+## Purpose
+
+Define the operator-facing contract for the AWS CloudFormation assets that deploy Payslip4All on EC2 with DynamoDB persistence and a public `payslip.co.za` entry point.
+
+## Audience
+
+- Operators deploying Payslip4All to AWS
+- Maintainers reviewing infrastructure changes
+
+## Scope
+
+This contract covers the CloudFormation template, its bootstrap inputs, required outputs, and recovery expectations. It does not define new runtime business behaviour inside Payslip4All.
+
+## Required Template Inputs
+
+The CloudFormation assets MUST accept or document operator-supplied values for:
+
+| Input | Purpose |
+|-------|---------|
+| `EnvironmentName` | Distinguishes environments such as production or staging |
+| `DomainName` | Public application hostname, expected to be `payslip.co.za` for the target environment |
+| `HostedZoneId` or equivalent DNS prerequisite | Allows the public hostname to resolve to the load balancer |
+| `CertificateArn` | Enables HTTPS on the public entry point |
+| `InstanceType` | Allows low-cost default compute with explicit override when needed |
+| `ArtifactSource` | Identifies what application build the instance should run |
+| `AllowedSshCidr` | Restricts operator shell access |
+| `DynamoDbRegion` | Satisfies the runtime requirement for the DynamoDB provider |
+| `DynamoDbTablePrefix` | Namespaces the application's table set |
+| Secret references for hosted-payment and app configuration | Supplies sensitive runtime values without hardcoding them in the template |
+
+## Required Infrastructure Behaviour
+
+The CloudFormation assets MUST:
+
+1. create one EC2-based Payslip4All web host,
+2. create an internet-facing load-balanced entry point for `payslip.co.za`,
+3. enforce secure HTTPS access and redirect insecure HTTP traffic,
+4. route application traffic to the EC2 instance only when health checks pass,
+5. configure the app to run with `PERSISTENCE_PROVIDER=dynamodb`,
+6. provide `DYNAMODB_REGION` and `DYNAMODB_TABLE_PREFIX` to the running app,
+7. prefer IAM-based AWS access from the instance over embedded static AWS credentials,
+8. identify the EC2 instance with payslip.co.za-derived metadata,
+9. avoid provisioning unnecessary paid services when a lower-cost supported alternative exists,
+10. enable automated DynamoDB recovery protection suitable for regular backups.
+
+## Required Outputs
+
+The CloudFormation assets MUST expose operator-usable outputs for:
+
+- the stack's public application URL,
+- the EC2 instance identifier,
+- the load balancer identifier,
+- the security-group identifiers needed for operator troubleshooting,
+- the secret/reference locations required for subsequent updates,
+- the recovery configuration reference or confirmation that DynamoDB protection is enabled.
+
+## Required Operator-Visible Signals
+
+The deployment MUST make these signals available to the operator:
+
+1. stack outputs that expose the public application URL, instance identifier, load balancer identifier, and backup protection mode,
+2. ALB target health for the registered EC2 instance,
+3. a health endpoint (`/health`) that allows first-pass application verification,
+4. deployment guidance that tells the operator how to inspect those signals together.
+
+## Security Rules
+
+The implementation MUST:
+
+- keep reusable secrets out of version-controlled plaintext files,
+- restrict direct instance access to explicitly approved operator ranges,
+- avoid exposing the application instance directly as the public production endpoint,
+- use the AWS SDK credential chain or AWS-managed secret references where possible,
+- preserve HTTPS as the default user path.
+
+The implementation MUST NOT:
+
+- commit reusable hosted-payment or runtime secrets into the CloudFormation template,
+- commit reusable hosted-payment or runtime secrets into the bootstrap script,
+- document plaintext reusable secret examples in the deployment guide.
+
+## Backup and Restore Rules
+
+The deployment MUST:
+
+- provide automated DynamoDB recoverability without requiring manual daily backup jobs,
+- preserve the ability to restore into a non-live target for safe recovery testing,
+- document the operator steps required to perform a restore and validate the result,
+- keep restore behaviour compatible with the repository's application-owned table namespace.
+
+## Manual Launch Workflow Limit
+
+The deployment documentation MUST keep the manual pre-launch workflow to no more than these five operator actions:
+
+1. publish the application artifact,
+2. confirm ACM certificate issuance,
+3. confirm Route 53 authority for `payslip.co.za`,
+4. gather external secret references,
+5. launch the CloudFormation stack with parameters.
+
+## Acceptance Conditions
+
+This contract is satisfied when:
+
+1. An operator can deploy Payslip4All to AWS through one CloudFormation-driven workflow.
+2. End users reach the app at `https://payslip.co.za` rather than through the EC2 instance directly.
+3. The running app boots successfully using the existing DynamoDB provider path and environment variables.
+4. Replacing the EC2 instance does not discard DynamoDB-backed application data.
+5. The deployment provides an operator-verifiable automated DynamoDB recovery path.
+6. The operator can verify deployment success using the required signal set without consulting undocumented AWS steps.
+7. The deployment assets and documentation do not embed reusable plaintext secrets.

--- a/specs/011-aws-cloudformation/data-model.md
+++ b/specs/011-aws-cloudformation/data-model.md
@@ -1,0 +1,206 @@
+# Data Model: AWS CloudFormation Deployment
+
+## Overview
+
+This feature does not introduce new business-domain persistence. Its data model describes the operator-facing infrastructure objects, configuration inputs, and recovery policies that the CloudFormation template and bootstrap assets must represent.
+
+## Entities
+
+### 1. Deployment Stack
+
+**Purpose**: The top-level AWS environment definition for one Payslip4All deployment.
+
+**Fields**:
+- `stackName` — operator-visible deployment name
+- `environmentName` — environment identifier such as `prod` or `staging`
+- `domainName` — public hostname served by the stack (`payslip.co.za`)
+- `region` — AWS region where the resources are launched
+- `artifactSource` — deployable application package or machine-image reference
+- `status` — current deployment lifecycle state
+
+**Relationships**:
+- Has one `Public Entry Point`
+- Has one `Application Instance`
+- Has one `Runtime Access Profile`
+- Has one `DynamoDB Runtime Configuration`
+- Has one `Backup Protection Policy`
+
+**Validation Rules**:
+- Must target one environment only.
+- Must expose one public domain only.
+- Must keep the application instance replaceable without coupling stack identity to one machine.
+
+### 2. Public Entry Point
+
+**Purpose**: The public traffic boundary that serves `payslip.co.za`.
+
+**Fields**:
+- `domainName` — public hostname
+- `tlsCertificateReference` — certificate identifier supplied to the stack
+- `httpRedirectEnabled` — whether insecure traffic is redirected to secure traffic
+- `healthCheckPath` — operator-defined application health path or probe target
+- `routingState` — whether the load balancer currently considers the target healthy
+- `signalOutputs` — operator-facing values that identify the public stack and health state
+
+**Relationships**:
+- Routes traffic to one `Application Instance`
+- Belongs to one `Deployment Stack`
+
+**Validation Rules**:
+- Must be the only public application entry point for the deployment.
+- Must enforce secure access.
+- Must stop routing traffic to unhealthy application targets.
+
+### 3. Application Instance
+
+**Purpose**: The single EC2-hosted Payslip4All web server.
+
+**Fields**:
+- `instanceType` — operator-selected or default low-cost instance size
+- `instanceName` — payslip.co.za-derived identification value
+- `bootstrapMode` — how the instance receives app artifacts and runtime configuration
+- `allowedIngressSources` — permitted upstream traffic sources
+- `replaceable` — whether the instance can be recreated without losing persistence
+
+**Relationships**:
+- Receives traffic from one `Public Entry Point`
+- Uses one `Runtime Access Profile`
+- Reads one `DynamoDB Runtime Configuration`
+
+**Validation Rules**:
+- Must not be the system of record for application data.
+- Must accept application traffic only from the load balancer and approved operator access ranges.
+- Must expose enough metadata for operators to identify it as the payslip.co.za host.
+
+### 4. Runtime Access Profile
+
+**Purpose**: The AWS permissions boundary used by the EC2 instance at runtime.
+
+**Fields**:
+- `profileName` — operator-visible role/profile identifier
+- `dynamoDbAccess` — whether table creation and data operations are allowed
+- `loggingAccess` — whether the app can publish operational logs and metrics
+- `secretReadAccess` — whether the app can read deployment secrets from AWS-managed stores
+
+**Relationships**:
+- Belongs to one `Application Instance`
+- Supports one `Deployment Stack`
+
+**Validation Rules**:
+- Must grant the minimum permissions required to run Payslip4All with DynamoDB.
+- Must allow the app to use the AWS SDK credential chain without embedded long-lived credentials.
+
+### 5. External Secret Reference
+
+**Purpose**: The operator-supplied reference used to inject sensitive runtime values without embedding reusable secrets in version-controlled assets.
+
+**Fields**:
+- `referenceType` — secret-store mechanism such as AWS-managed secret reference
+- `scope` — which runtime settings it provides
+- `rotationOwner` — who manages secret value updates
+- `bootstrapConsumptionMode` — how the EC2 bootstrap flow reads the referenced secret
+
+**Relationships**:
+- Supports one `Deployment Stack`
+- Supports one `Runtime Access Profile`
+
+**Validation Rules**:
+- Must not include plaintext reusable secret values in source-controlled artifacts.
+- Must be optional only when the deployment genuinely has no secret-backed runtime settings to inject.
+
+### 6. DynamoDB Runtime Configuration
+
+**Purpose**: The set of runtime values the app needs in order to use the existing DynamoDB provider path.
+
+**Fields**:
+- `persistenceProvider` — must be `dynamodb`
+- `region` — runtime DynamoDB region value
+- `tablePrefix` — logical namespace for application tables
+- `credentialMode` — IAM role or explicit credentials
+- `startupValidationState` — whether the app has the required values to boot successfully
+
+**Relationships**:
+- Used by one `Application Instance`
+- Protected by one `Backup Protection Policy`
+
+**Validation Rules**:
+- `persistenceProvider` must always be `dynamodb` for this feature.
+- `region` must be supplied.
+- Explicit AWS credentials, if used, must be complete pairs and not partial values.
+
+### 7. Backup Protection Policy
+
+**Purpose**: The automated recoverability configuration for the application's DynamoDB tables.
+
+**Fields**:
+- `recoveryMode` — continuous or scheduled protection method
+- `recoveryWindow` — amount of time data remains restorable
+- `restoreTargetStrategy` — how recovered data is materialized
+- `operatorRunbookReference` — restore procedure location
+
+**Relationships**:
+- Protects one `DynamoDB Runtime Configuration`
+- Supports one `Deployment Stack`
+
+**Validation Rules**:
+- Must provide automated recoverability without manual daily intervention.
+- Must support safe restore exercises that do not overwrite the live tables in place.
+
+### 8. Operator Signal Set
+
+**Purpose**: The minimum deployment and health signals the operator uses to verify launch success.
+
+**Fields**:
+- `applicationUrl` — public HTTPS address exposed through stack outputs
+- `instanceId` — EC2 runtime identifier
+- `loadBalancerReference` — ALB identifier or ARN
+- `securityGroupReference` — network identifiers used during troubleshooting
+- `healthEndpoint` — public or proxied `/health` probe location
+- `targetHealthState` — ALB routing view of instance health
+- `backupMode` — backup protection state surfaced to operators
+
+**Relationships**:
+- Belongs to one `Deployment Stack`
+- Observes one `Public Entry Point`
+- Observes one `Application Instance`
+- Reflects one `Backup Protection Policy`
+
+**Validation Rules**:
+- Must be sufficient to confirm stack identity, application reachability, and recovery mode.
+- Must stay minimal enough that the feature does not become a full monitoring-platform project.
+
+### 9. Operator Launch Workflow
+
+**Purpose**: The measurable set of manual steps an operator performs before stack creation succeeds.
+
+**Fields**:
+- `artifactPublished` — whether the deployable bundle is ready
+- `certificateReady` — whether the ACM certificate is issued
+- `dnsAuthorityConfirmed` — whether Route 53 prerequisites are satisfied
+- `secretReferencesGathered` — whether external secret references are ready
+- `stackLaunchSubmitted` — whether the operator executed the CloudFormation deployment
+
+**Relationships**:
+- Belongs to one `Deployment Stack`
+
+**Validation Rules**:
+- Must not exceed five manual pre-launch actions.
+- Must map directly to the workflow documented in the deployment guide and quickstart.
+
+## State Model
+
+### Deployment Lifecycle
+
+1. `Prepared` — operator has gathered domain, certificate, artifact, secret, and access inputs.
+2. `Provisioning` — CloudFormation is creating or updating infrastructure resources.
+3. `Bootstrapping` — EC2 is starting Payslip4All with DynamoDB configuration and initial table provisioning.
+4. `Healthy` — the ALB routes secure traffic to the instance and the application is reachable at `payslip.co.za`.
+5. `Recovering` — operator is restoring DynamoDB data from the defined backup mechanism.
+
+**Transitions**:
+- `Prepared -> Provisioning`: operator launches the CloudFormation stack with valid inputs.
+- `Provisioning -> Bootstrapping`: AWS resources are created and the instance begins startup.
+- `Bootstrapping -> Healthy`: the app passes health checks and serves traffic through the ALB.
+- `Healthy -> Recovering`: operator initiates a DynamoDB restore workflow.
+- `Recovering -> Healthy`: restored data is validated and the environment returns to normal service.
+- Any state can regress if DNS, TLS, permissions, or DynamoDB runtime configuration becomes invalid.

--- a/specs/011-aws-cloudformation/data-model.md
+++ b/specs/011-aws-cloudformation/data-model.md
@@ -13,7 +13,7 @@ This feature does not introduce new business-domain persistence. Its data model 
 **Fields**:
 - `stackName` — operator-visible deployment name
 - `environmentName` — environment identifier such as `prod` or `staging`
-- `domainName` — public hostname served by the stack (`payslip.co.za`)
+- `domainName` — public hostname served by the stack (`payslip4all.co.za`)
 - `region` — AWS region where the resources are launched
 - `artifactSource` — deployable application package or machine-image reference
 - `status` — current deployment lifecycle state
@@ -32,7 +32,7 @@ This feature does not introduce new business-domain persistence. Its data model 
 
 ### 2. Public Entry Point
 
-**Purpose**: The public traffic boundary that serves `payslip.co.za`.
+**Purpose**: The public traffic boundary that serves `payslip4all.co.za`.
 
 **Fields**:
 - `domainName` — public hostname
@@ -57,7 +57,7 @@ This feature does not introduce new business-domain persistence. Its data model 
 
 **Fields**:
 - `instanceType` — operator-selected or default low-cost instance size
-- `instanceName` — payslip.co.za-derived identification value
+- `instanceName` — payslip4all.co.za-derived identification value
 - `bootstrapMode` — how the instance receives app artifacts and runtime configuration
 - `allowedIngressSources` — permitted upstream traffic sources
 - `replaceable` — whether the instance can be recreated without losing persistence
@@ -70,7 +70,7 @@ This feature does not introduce new business-domain persistence. Its data model 
 **Validation Rules**:
 - Must not be the system of record for application data.
 - Must accept application traffic only from the load balancer and approved operator access ranges.
-- Must expose enough metadata for operators to identify it as the payslip.co.za host.
+- Must expose enough metadata for operators to identify it as the payslip4all.co.za host.
 
 ### 4. Runtime Access Profile
 
@@ -194,7 +194,7 @@ This feature does not introduce new business-domain persistence. Its data model 
 1. `Prepared` — operator has gathered domain, certificate, artifact, secret, and access inputs.
 2. `Provisioning` — CloudFormation is creating or updating infrastructure resources.
 3. `Bootstrapping` — EC2 is starting Payslip4All with DynamoDB configuration and initial table provisioning.
-4. `Healthy` — the ALB routes secure traffic to the instance and the application is reachable at `payslip.co.za`.
+4. `Healthy` — the ALB routes secure traffic to the instance and the application is reachable at `payslip4all.co.za`.
 5. `Recovering` — operator is restoring DynamoDB data from the defined backup mechanism.
 
 **Transitions**:

--- a/specs/011-aws-cloudformation/plan.md
+++ b/specs/011-aws-cloudformation/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Deliver a CloudFormation-first AWS deployment path for Payslip4All that runs the web app on one EC2 instance behind an internet-facing ALB, publishes `payslip.co.za` through Route 53 and ACM, uses the existing DynamoDB provider path, and enables automated DynamoDB point-in-time recovery. The refined plan makes the operator-visible signal set explicit, keeps reusable secrets out of committed assets, and constrains the manual pre-launch workflow to five actions so success criteria remain testable.
+Deliver a CloudFormation-first AWS deployment path for Payslip4All that runs the web app on one EC2 instance behind an internet-facing ALB, publishes `payslip4all.co.za` through Route 53 and ACM, uses the existing DynamoDB provider path, and enables automated DynamoDB point-in-time recovery. The refined plan makes the operator-visible signal set explicit, keeps reusable secrets out of committed assets, and constrains the manual pre-launch workflow to five actions so success criteria remain testable.
 
 ## Technical Context
 
@@ -15,8 +15,8 @@ Deliver a CloudFormation-first AWS deployment path for Payslip4All that runs the
 **Testing**: Existing `dotnet test` suites plus xUnit/WebApplicationFactory coverage for CloudFormation contract checks, deployment documentation, startup health endpoint registration, DynamoDB backup protection, and focused validation of the five-step operator workflow  
 **Target Platform**: AWS single-environment deployment running the ASP.NET Core Blazor Server app on Linux EC2 behind an internet-facing load balancer  
 **Project Type**: Infrastructure feature for an existing Clean Architecture web application  
-**Performance Goals**: Support stack launch within 45 minutes after prerequisites are ready, first page load through `payslip.co.za` within 10 seconds in smoke tests, DynamoDB recovery drills within 60 minutes, and expose operator-visible signals through stack outputs, ALB target health, `/health`, and deployment documentation  
-**Constraints**: Must use one EC2 instance for the web app, DynamoDB for persistence, `payslip.co.za` as the public load-balancer address, payslip.co.za-derived instance identification, secure HTTPS access, health-based routing, no hardcoded reusable secrets, no more than five manual pre-launch setup actions, and the lowest practical ongoing cost; ALB and Route 53 remain expected paid services  
+**Performance Goals**: Support stack launch within 45 minutes after prerequisites are ready, first page load through `payslip4all.co.za` within 10 seconds in smoke tests, DynamoDB recovery drills within 60 minutes, and expose operator-visible signals through stack outputs, ALB target health, `/health`, and deployment documentation  
+**Constraints**: Must use one EC2 instance for the web app, DynamoDB for persistence, `payslip4all.co.za` as the public load-balancer address, payslip4all.co.za-derived instance identification, secure HTTPS access, health-based routing, no hardcoded reusable secrets, no more than five manual pre-launch setup actions, and the lowest practical ongoing cost; ALB and Route 53 remain expected paid services  
 **Scale/Scope**: One low-traffic environment, one replaceable web instance, application-owned DynamoDB tables auto-created at startup, explicit operator signals limited to stack outputs plus documented runtime health checks, and implementation scoped to infrastructure assets, startup configuration glue, docs, and tests inside the four-project repository
 
 ## Constitution Check
@@ -91,7 +91,7 @@ specs/011-aws-cloudformation/
 
 ## Phase 0 Research Outcome
 
-- The lowest-cost architecture that still satisfies the spec is a single EC2 instance in a public subnet behind an internet-facing ALB, with Route 53 aliasing `payslip.co.za` to the ALB and payslip.co.za-derived instance tagging for operator identification.
+- The lowest-cost architecture that still satisfies the spec is a single EC2 instance in a public subnet behind an internet-facing ALB, with Route 53 aliasing `payslip4all.co.za` to the ALB and payslip4all.co.za-derived instance tagging for operator identification.
 - Required operator-visible signals are now fixed as: CloudFormation outputs for `ApplicationUrl`, `InstanceId`, `LoadBalancerArn`, security-group identifiers, and backup mode; ALB target health; the public `/health` endpoint; and deployment runbook guidance that ties those signals together.
 - Reusable secrets must stay out of committed template values, bootstrap scripts, and docs; the supported patterns are IAM instance profiles plus external secret references such as AWS Secrets Manager.
 - The pre-launch workflow is constrained to five manual actions: publish the app artifact, confirm ACM issuance, confirm Route 53 authority, gather secret references, and launch the CloudFormation stack with parameters.

--- a/specs/011-aws-cloudformation/plan.md
+++ b/specs/011-aws-cloudformation/plan.md
@@ -1,0 +1,115 @@
+# Implementation Plan: AWS CloudFormation Deployment
+
+**Branch**: `011-aws-cloudformation` | **Date**: 2026-04-07 | **Spec**: `specs/011-aws-cloudformation/spec.md`  
+**Input**: Feature specification from `specs/011-aws-cloudformation/spec.md`
+
+## Summary
+
+Deliver a CloudFormation-first AWS deployment path for Payslip4All that runs the web app on one EC2 instance behind an internet-facing ALB, publishes `payslip.co.za` through Route 53 and ACM, uses the existing DynamoDB provider path, and enables automated DynamoDB point-in-time recovery. The refined plan makes the operator-visible signal set explicit, keeps reusable secrets out of committed assets, and constrains the manual pre-launch workflow to five actions so success criteria remain testable.
+
+## Technical Context
+
+**Language/Version**: YAML infrastructure-as-code plus existing C# 12 / .NET 8 application configuration  
+**Primary Dependencies**: AWS CloudFormation, EC2, Application Load Balancer, Route 53, ACM, IAM, CloudWatch-linked operational signals, existing `PERSISTENCE_PROVIDER=dynamodb` runtime path, existing DynamoDB table provisioner, new backup-protection hosted service  
+**Storage**: DynamoDB with the repository's multi-table auto-provisioning model and hosted AWS point-in-time recovery enabled for regular backups  
+**Testing**: Existing `dotnet test` suites plus xUnit/WebApplicationFactory coverage for CloudFormation contract checks, deployment documentation, startup health endpoint registration, DynamoDB backup protection, and focused validation of the five-step operator workflow  
+**Target Platform**: AWS single-environment deployment running the ASP.NET Core Blazor Server app on Linux EC2 behind an internet-facing load balancer  
+**Project Type**: Infrastructure feature for an existing Clean Architecture web application  
+**Performance Goals**: Support stack launch within 45 minutes after prerequisites are ready, first page load through `payslip.co.za` within 10 seconds in smoke tests, DynamoDB recovery drills within 60 minutes, and expose operator-visible signals through stack outputs, ALB target health, `/health`, and deployment documentation  
+**Constraints**: Must use one EC2 instance for the web app, DynamoDB for persistence, `payslip.co.za` as the public load-balancer address, payslip.co.za-derived instance identification, secure HTTPS access, health-based routing, no hardcoded reusable secrets, no more than five manual pre-launch setup actions, and the lowest practical ongoing cost; ALB and Route 53 remain expected paid services  
+**Scale/Scope**: One low-traffic environment, one replaceable web instance, application-owned DynamoDB tables auto-created at startup, explicit operator signals limited to stack outputs plus documented runtime health checks, and implementation scoped to infrastructure assets, startup configuration glue, docs, and tests inside the four-project repository
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| # | Principle | Gate Question | Status |
+|---|-----------|---------------|--------|
+| I | TDD | Are failing tests planned/written before any implementation task begins? | PASS |
+| II | Clean Architecture | Does the feature touch ≤ 4 projects (Domain/Application/Infrastructure/Web)? Does each layer only depend inward? | PASS |
+| III | Blazor Web App | Are all new UI surfaces Razor components? Is business logic kept out of `.razor` files? | PASS |
+| IV | Basic Authentication | Do new pages carry `[Authorize]`? Do new service methods filter by `UserId`? | PASS |
+| V | Database Support | For EF Core providers (SQLite/MySQL): are all schema changes EF Core migrations? Is raw SQL avoided? For DynamoDB provider (`PERSISTENCE_PROVIDER=dynamodb`): do DynamoDB repositories implement all Application interfaces? Is ownership filtering enforced? | PASS |
+| VI | Manual Test Gate | Is the Manual Test Gate prompt planned at the end of each implementation task, before any `git commit`, `git merge`, or `git push`? | PASS |
+
+### Constitution Gate Notes
+
+- **Pre-research gate**: Passed because the feature adds deployment assets and startup configuration only. It does not introduce new business rules, change auth boundaries, or add projects outside the existing four-project constitution limit.
+- **Post-design re-check**: Passed because the refined design keeps the DynamoDB provider logic in Infrastructure, the health endpoint in Web, and all verification within existing xUnit/WebApplicationFactory patterns. The plan also explicitly preserves TDD-first implementation and the Manual Test Gate before any git operations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/011-aws-cloudformation/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── cloudformation-deployment-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+.
+├── infra/
+│   └── aws/
+│       └── cloudformation/
+│           ├── payslip4all-web.yaml
+│           ├── README.md
+│           └── user-data/
+│               └── bootstrap-payslip4all.sh
+├── src/
+│   ├── Payslip4All.Infrastructure/
+│   │   └── Persistence/
+│   │       └── DynamoDB/
+│   │           ├── DynamoDbBackupProtectionHostedService.cs
+│   │           ├── DynamoDbServiceExtensions.cs
+│   │           └── DynamoDbTableProvisioner.cs
+│   └── Payslip4All.Web/
+│       ├── Endpoints/
+│       │   └── HealthEndpoint.cs
+│       └── Program.cs
+└── tests/
+    ├── Payslip4All.Infrastructure.Tests/
+    │   └── Persistence/
+    │       └── DynamoDB/
+    │           └── DynamoDbBackupProtectionTests.cs
+    └── Payslip4All.Web.Tests/
+        ├── Infrastructure/
+        │   ├── AwsCloudFormationTemplateTests.cs
+        │   └── AwsDeploymentDocumentationTests.cs
+        └── Startup/
+            └── AwsDeploymentStartupTests.cs
+```
+
+**Structure Decision**: Keep deployable infrastructure assets under `infra/aws/cloudformation/`, keep runtime startup and backup-protection logic inside the existing Web and Infrastructure projects, and validate all deployment behavior through the existing .NET test projects. This structure makes the actual implementation surface explicit instead of treating the source tree as a partial placeholder.
+
+## Phase 0 Research Outcome
+
+- The lowest-cost architecture that still satisfies the spec is a single EC2 instance in a public subnet behind an internet-facing ALB, with Route 53 aliasing `payslip.co.za` to the ALB and payslip.co.za-derived instance tagging for operator identification.
+- Required operator-visible signals are now fixed as: CloudFormation outputs for `ApplicationUrl`, `InstanceId`, `LoadBalancerArn`, security-group identifiers, and backup mode; ALB target health; the public `/health` endpoint; and deployment runbook guidance that ties those signals together.
+- Reusable secrets must stay out of committed template values, bootstrap scripts, and docs; the supported patterns are IAM instance profiles plus external secret references such as AWS Secrets Manager.
+- The pre-launch workflow is constrained to five manual actions: publish the app artifact, confirm ACM issuance, confirm Route 53 authority, gather secret references, and launch the CloudFormation stack with parameters.
+- The repository's DynamoDB path still requires `PERSISTENCE_PROVIDER=dynamodb`, `DYNAMODB_REGION`, and a table prefix, and the AWS SDK credential chain remains the preferred hosted-AWS credential strategy.
+- Point-in-time recovery remains the default interpretation of "regularly backed up" because it provides continuous recoverability with less operator and cost overhead than AWS Backup across every application table.
+
+## Phase 1 Design Output
+
+- `research.md` captures the architecture, signal-set, secret-handling, backup, and cost decisions that resolve the analysis gaps.
+- `data-model.md` defines the operator-facing deployment entities, explicit signal set, external secret handling boundary, and five-step launch workflow constraints.
+- `contracts/cloudformation-deployment-contract.md` defines the CloudFormation contract including required inputs, outputs, operator-visible signals, security expectations, backup behavior, and launch-step limits.
+- `quickstart.md` defines the verification flow for launch, public-domain reachability, signal inspection, DynamoDB startup, replaceable compute, and restore readiness while staying within the documented operator workflow.
+- `.github/agents/copilot-instructions.md` will be refreshed by the repository helper script so future implementation or review agents inherit the tightened AWS deployment context.
+
+## Complexity Tracking
+
+No constitutional exceptions are required for this feature.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | — | — |

--- a/specs/011-aws-cloudformation/quickstart.md
+++ b/specs/011-aws-cloudformation/quickstart.md
@@ -1,0 +1,86 @@
+# Quickstart: AWS CloudFormation Deployment
+
+## Purpose
+
+Validate that the planned CloudFormation assets are sufficient to launch, verify, and recover a low-cost AWS-hosted Payslip4All environment using EC2, ALB, Route 53, and DynamoDB.
+
+## Prerequisites
+
+- AWS account with permission to create EC2, ALB, Route 53, IAM, CloudWatch, and DynamoDB resources
+- Control of the `payslip.co.za` DNS zone or the ability to create the required Route 53 records
+- An ACM certificate for `payslip.co.za` in the same AWS region as the load balancer
+- A deployable Payslip4All application artifact
+- Hosted-payment and application secrets stored outside source control
+- A chosen DynamoDB region and table prefix
+- An operator IP range for SSH administration, if SSH is enabled
+
+## Scenario 1: Prepare deployment inputs
+
+1. Publish or stage the deployment artifact referenced by `ArtifactSource`.
+2. Confirm the ACM certificate for `payslip.co.za` is issued in the target region.
+3. Confirm the Route 53 hosted zone is authoritative for `payslip.co.za`.
+4. Gather the external secret references required by the deployment.
+5. Launch the CloudFormation template with the required parameters, including the intended environment name and DynamoDB runtime values.
+
+These five actions define the full manual pre-launch workflow for SC-005.
+
+## Scenario 2: Launch the stack
+
+1. Deploy the CloudFormation template with the prepared parameters.
+2. Wait for stack completion.
+3. Confirm the deployed resources include:
+   - one EC2 application instance,
+   - one internet-facing load balancer,
+   - DNS wiring for `payslip.co.za`,
+   - runtime configuration for DynamoDB,
+   - automated DynamoDB recovery protection.
+
+## Scenario 3: Verify public access through `payslip.co.za`
+
+1. Open `https://payslip.co.za`.
+2. Confirm the browser reaches Payslip4All through HTTPS.
+3. Confirm insecure HTTP is redirected to HTTPS.
+4. Confirm the instance is identified in AWS with payslip.co.za-derived metadata.
+
+## Scenario 4: Verify operator-visible signals
+
+1. Read the stack outputs.
+2. Confirm the outputs expose:
+    - the public application URL,
+    - the EC2 instance identifier,
+    - the load balancer identifier,
+    - the instance and load-balancer security-group identifiers,
+    - the backup protection mode or restore reference.
+3. Inspect ALB target health and confirm the registered instance is healthy.
+4. Call `/health` and confirm the application returns a healthy response.
+
+## Scenario 5: Verify DynamoDB-backed startup
+
+1. Inspect the running application's environment configuration.
+2. Confirm the app is configured with:
+   - `PERSISTENCE_PROVIDER=dynamodb`,
+   - `DYNAMODB_REGION`,
+   - `DYNAMODB_TABLE_PREFIX`.
+3. Confirm the application starts successfully and the existing DynamoDB table provisioner can create or verify its required tables.
+
+## Scenario 6: Verify replaceable compute
+
+1. Replace or recreate the EC2 instance through the deployment workflow.
+2. Confirm the public entry point remains the same.
+3. Confirm application data remains available after the replacement.
+
+## Scenario 7: Verify backup and restore readiness
+
+1. Confirm automated DynamoDB recovery protection is enabled for the application's tables.
+2. Record the documented restore steps.
+3. Run a recovery exercise that restores data into a safe target and validate the restored data before any cutover decision.
+
+## Scenario 8: Verify secret externalization
+
+1. Inspect the CloudFormation template, bootstrap script, and deployment guide.
+2. Confirm reusable hosted-payment or runtime secrets are referenced externally rather than embedded as plaintext values.
+3. Confirm the deployment guide uses secret references and placeholders instead of reusable secret examples.
+
+## Validation Outcome
+
+The feature is ready for implementation when the planned assets and instructions support all eight scenarios above without requiring undocumented AWS setup steps or manual recreation of infrastructure outside the CloudFormation workflow.

--- a/specs/011-aws-cloudformation/quickstart.md
+++ b/specs/011-aws-cloudformation/quickstart.md
@@ -7,8 +7,8 @@ Validate that the planned CloudFormation assets are sufficient to launch, verify
 ## Prerequisites
 
 - AWS account with permission to create EC2, ALB, Route 53, IAM, CloudWatch, and DynamoDB resources
-- Control of the `payslip.co.za` DNS zone or the ability to create the required Route 53 records
-- An ACM certificate for `payslip.co.za` in the same AWS region as the load balancer
+- Control of the `payslip4all.co.za` DNS zone or the ability to create the required Route 53 records
+- An ACM certificate for `payslip4all.co.za` in the same AWS region as the load balancer
 - A deployable Payslip4All application artifact
 - Hosted-payment and application secrets stored outside source control
 - A chosen DynamoDB region and table prefix
@@ -17,8 +17,8 @@ Validate that the planned CloudFormation assets are sufficient to launch, verify
 ## Scenario 1: Prepare deployment inputs
 
 1. Publish or stage the deployment artifact referenced by `ArtifactSource`.
-2. Confirm the ACM certificate for `payslip.co.za` is issued in the target region.
-3. Confirm the Route 53 hosted zone is authoritative for `payslip.co.za`.
+2. Confirm the ACM certificate for `payslip4all.co.za` is issued in the target region.
+3. Confirm the Route 53 hosted zone is authoritative for `payslip4all.co.za`.
 4. Gather the external secret references required by the deployment.
 5. Launch the CloudFormation template with the required parameters, including the intended environment name and DynamoDB runtime values.
 
@@ -31,16 +31,16 @@ These five actions define the full manual pre-launch workflow for SC-005.
 3. Confirm the deployed resources include:
    - one EC2 application instance,
    - one internet-facing load balancer,
-   - DNS wiring for `payslip.co.za`,
+   - DNS wiring for `payslip4all.co.za`,
    - runtime configuration for DynamoDB,
    - automated DynamoDB recovery protection.
 
-## Scenario 3: Verify public access through `payslip.co.za`
+## Scenario 3: Verify public access through `payslip4all.co.za`
 
-1. Open `https://payslip.co.za`.
+1. Open `https://payslip4all.co.za`.
 2. Confirm the browser reaches Payslip4All through HTTPS.
 3. Confirm insecure HTTP is redirected to HTTPS.
-4. Confirm the instance is identified in AWS with payslip.co.za-derived metadata.
+4. Confirm the instance is identified in AWS with payslip4all.co.za-derived metadata.
 
 ## Scenario 4: Verify operator-visible signals
 

--- a/specs/011-aws-cloudformation/research.md
+++ b/specs/011-aws-cloudformation/research.md
@@ -3,7 +3,7 @@
 ## Decision 1: Use a single EC2 instance behind an internet-facing ALB
 
 - **Decision**: Deploy Payslip4All on one Linux EC2 instance and place it behind an internet-facing Application Load Balancer.
-- **Rationale**: The feature explicitly requires both an EC2-hosted web app and a load-balanced public entry point. A single instance keeps compute cost low while the ALB satisfies HTTPS termination, health checks, and stable routing through `payslip.co.za`.
+- **Rationale**: The feature explicitly requires both an EC2-hosted web app and a load-balanced public entry point. A single instance keeps compute cost low while the ALB satisfies HTTPS termination, health checks, and stable routing through `payslip4all.co.za`.
 - **Alternatives considered**:
   - **Expose EC2 directly with an Elastic IP**: Rejected because it does not satisfy the load-balancer requirement or health-based routing requirement.
   - **Use an Auto Scaling group with multiple instances**: Rejected because it adds cost and operational complexity beyond the feature's low-cost single-environment scope.
@@ -16,17 +16,17 @@
   - **Private subnet plus NAT gateway**: Rejected because the NAT gateway materially increases monthly cost in a feature that is explicitly cost-sensitive.
   - **Private subnet plus multiple VPC endpoints**: Rejected because it adds design and implementation complexity that is unnecessary for the single-instance scope.
 
-## Decision 3: Point `payslip.co.za` at the ALB and use payslip.co.za-derived tags for the EC2 instance
+## Decision 3: Point `payslip4all.co.za` at the ALB and use payslip4all.co.za-derived tags for the EC2 instance
 
-- **Decision**: Route the public apex domain `payslip.co.za` to the ALB and identify the EC2 instance with a payslip.co.za-derived name or tag such as `payslip-co-za-web-prod`.
+- **Decision**: Route the public apex domain `payslip4all.co.za` to the ALB and identify the EC2 instance with a payslip4all.co.za-derived name or tag such as `payslip4all-co-za-web-prod`.
 - **Rationale**: One public DNS name cannot safely represent both the load balancer and the instance at the same time. Using the apex domain only for the public entry point keeps DNS valid while still giving operators a clear way to recognize the backing instance.
 - **Alternatives considered**:
-  - **Assign `payslip.co.za` directly to the EC2 instance as well**: Rejected because it conflicts with the ALB requirement and creates ambiguous routing.
+  - **Assign `payslip4all.co.za` directly to the EC2 instance as well**: Rejected because it conflicts with the ALB requirement and creates ambiguous routing.
   - **Create a second public name for the instance**: Rejected because the spec does not ask for a second public endpoint and that would weaken the single-entry-point design.
 
 ## Decision 4: Use an ACM certificate and Route 53 alias records for the public domain
 
-- **Decision**: Use an ACM public certificate in the same AWS region as the ALB and create a Route 53 alias record from `payslip.co.za` to the ALB.
+- **Decision**: Use an ACM public certificate in the same AWS region as the ALB and create a Route 53 alias record from `payslip4all.co.za` to the ALB.
 - **Rationale**: ACM certificates integrate directly with ALB listeners and do not add certificate-management cost. Route 53 aliasing provides the cleanest supported way to serve an apex domain through an ALB.
 - **Alternatives considered**:
   - **Terminate TLS on the EC2 instance only**: Rejected because HTTPS redirection and load-balancer health checks are simpler and safer when TLS terminates at the ALB.

--- a/specs/011-aws-cloudformation/research.md
+++ b/specs/011-aws-cloudformation/research.md
@@ -1,0 +1,97 @@
+# Research: AWS CloudFormation Deployment
+
+## Decision 1: Use a single EC2 instance behind an internet-facing ALB
+
+- **Decision**: Deploy Payslip4All on one Linux EC2 instance and place it behind an internet-facing Application Load Balancer.
+- **Rationale**: The feature explicitly requires both an EC2-hosted web app and a load-balanced public entry point. A single instance keeps compute cost low while the ALB satisfies HTTPS termination, health checks, and stable routing through `payslip.co.za`.
+- **Alternatives considered**:
+  - **Expose EC2 directly with an Elastic IP**: Rejected because it does not satisfy the load-balancer requirement or health-based routing requirement.
+  - **Use an Auto Scaling group with multiple instances**: Rejected because it adds cost and operational complexity beyond the feature's low-cost single-environment scope.
+
+## Decision 2: Keep the EC2 instance in a public subnet and restrict inbound traffic by security group
+
+- **Decision**: Place the EC2 instance in a public subnet, allow application traffic only from the ALB security group, and allow SSH only from an operator-supplied CIDR.
+- **Rationale**: This avoids a NAT gateway and its recurring cost while still allowing the instance to reach AWS APIs and deployment artifact sources. The security-group design preserves a low-cost footprint without opening the app directly to the internet.
+- **Alternatives considered**:
+  - **Private subnet plus NAT gateway**: Rejected because the NAT gateway materially increases monthly cost in a feature that is explicitly cost-sensitive.
+  - **Private subnet plus multiple VPC endpoints**: Rejected because it adds design and implementation complexity that is unnecessary for the single-instance scope.
+
+## Decision 3: Point `payslip.co.za` at the ALB and use payslip.co.za-derived tags for the EC2 instance
+
+- **Decision**: Route the public apex domain `payslip.co.za` to the ALB and identify the EC2 instance with a payslip.co.za-derived name or tag such as `payslip-co-za-web-prod`.
+- **Rationale**: One public DNS name cannot safely represent both the load balancer and the instance at the same time. Using the apex domain only for the public entry point keeps DNS valid while still giving operators a clear way to recognize the backing instance.
+- **Alternatives considered**:
+  - **Assign `payslip.co.za` directly to the EC2 instance as well**: Rejected because it conflicts with the ALB requirement and creates ambiguous routing.
+  - **Create a second public name for the instance**: Rejected because the spec does not ask for a second public endpoint and that would weaken the single-entry-point design.
+
+## Decision 4: Use an ACM certificate and Route 53 alias records for the public domain
+
+- **Decision**: Use an ACM public certificate in the same AWS region as the ALB and create a Route 53 alias record from `payslip.co.za` to the ALB.
+- **Rationale**: ACM certificates integrate directly with ALB listeners and do not add certificate-management cost. Route 53 aliasing provides the cleanest supported way to serve an apex domain through an ALB.
+- **Alternatives considered**:
+  - **Terminate TLS on the EC2 instance only**: Rejected because HTTPS redirection and load-balancer health checks are simpler and safer when TLS terminates at the ALB.
+  - **Use an external DNS provider with manual records**: Rejected because the feature is specifically about an AWS-managed deployment template.
+
+## Decision 5: Use the existing application-owned DynamoDB provisioning path
+
+- **Decision**: Configure the stack to run Payslip4All with `PERSISTENCE_PROVIDER=dynamodb` and let the existing `DynamoDbTableProvisioner` create the required tables at startup with on-demand billing.
+- **Rationale**: The repository already has a full DynamoDB provider path and startup provisioning service. Reusing it avoids duplicating table definitions and keeps CloudFormation focused on the infrastructure boundary rather than application-owned schema details.
+- **Alternatives considered**:
+  - **Declare every DynamoDB table in CloudFormation**: Rejected because it would duplicate table structure already encoded in application startup logic and increase maintenance drift.
+  - **Keep SQLite or MySQL for the first AWS deployment**: Rejected because the feature explicitly requires DynamoDB persistence.
+
+## Decision 6: Prefer an IAM instance profile over static AWS credentials
+
+- **Decision**: Grant the EC2 instance an IAM role with the DynamoDB, logging, and secret-read permissions it needs, and rely on the AWS SDK credential chain instead of storing AWS access keys in the template.
+- **Rationale**: `Program.cs` and the DynamoDB client path already support the AWS SDK default credential chain when explicit keys are absent. IAM roles are safer, simpler to rotate, and better aligned with the spec's no-hardcoded-secrets requirement.
+- **Alternatives considered**:
+  - **Pass `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` into the instance**: Rejected because it creates unnecessary credential-management risk.
+  - **Use long-lived shared credentials files on the instance**: Rejected because it is harder to automate safely through CloudFormation.
+
+## Decision 7: Enable DynamoDB point-in-time recovery on all application tables
+
+- **Decision**: Turn on DynamoDB point-in-time recovery for the Payslip4All table set and document operator-led restore steps that restore into new tables.
+- **Rationale**: PITR satisfies the requirement for regular backups with minimal daily operational overhead and supports safer recovery drills because restores create new tables instead of overwriting live ones.
+- **Alternatives considered**:
+  - **Use AWS Backup with scheduled backup plans only**: Rejected as the default because it adds cost and administration overhead across every table in this low-cost deployment.
+  - **Rely on ad-hoc manual on-demand backups**: Rejected because it does not satisfy the "regularly backed up" requirement.
+
+## Decision 8: Be explicit that the deployment is low-cost optimized, not zero-cost
+
+- **Decision**: Design the template to minimize cost with a single instance, on-demand DynamoDB billing, and no NAT gateway, while documenting that ALB, Route 53, and backup features are expected recurring costs outside the free tier.
+- **Rationale**: The spec asks to use as much of the free tier as possible, but the required public-domain and load-balancer features inherently introduce some paid AWS services. Making that tradeoff explicit keeps the plan honest and implementation-safe.
+- **Alternatives considered**:
+  - **Claim the whole deployment can stay inside the free tier**: Rejected because the mandatory edge services make that unrealistic.
+  - **Drop the load balancer to chase lower cost**: Rejected because it would violate the feature requirements.
+
+## Decision 9: Treat deployment artifacts as a repository-owned infrastructure surface
+
+- **Decision**: Store the CloudFormation template and its bootstrap script under `infra/aws/cloudformation/` and validate them through the repository's existing .NET test suites.
+- **Rationale**: The infrastructure assets should evolve with the application code they configure, and keeping validation in the existing test projects avoids introducing a new testing stack during this feature.
+- **Alternatives considered**:
+  - **Keep infrastructure files outside the repository**: Rejected because the feature requires the deployment template to ship with the application.
+  - **Introduce a separate infrastructure test framework immediately**: Rejected because the repo already has established xUnit-based validation patterns.
+
+## Decision 10: Make the operator-visible signal set explicit and minimal
+
+- **Decision**: Treat the minimum required operator-visible signals as CloudFormation outputs (`ApplicationUrl`, `InstanceId`, `LoadBalancerArn`, security-group identifiers, backup mode), ALB target health, and the public `/health` endpoint documented in the deployment guide.
+- **Rationale**: The analysis pass showed that “operator-visible health and deployment signals” was otherwise open to interpretation. Fixing the signal set keeps the requirement testable without expanding the feature into a broader observability platform project.
+- **Alternatives considered**:
+  - **Leave signals loosely defined**: Rejected because it makes FR-009 and related tests ambiguous.
+  - **Require full alarm dashboards and a dedicated monitoring stack**: Rejected because it would expand scope beyond the requested deployment feature.
+
+## Decision 11: Enforce external secret handling as a first-class deployment rule
+
+- **Decision**: The template, bootstrap flow, and deployment docs must all avoid embedding reusable secrets directly; hosted-payment and app-specific secrets must come from operator-supplied external references.
+- **Rationale**: Secret handling was already implied by the spec, but tightening it into an explicit design rule makes FR-006 testable and keeps the deployment guidance aligned with the constitution’s no-secrets policy.
+- **Alternatives considered**:
+  - **Allow plaintext example secrets in the bootstrap flow**: Rejected because it normalizes unsafe operational practices.
+  - **Rely only on prose warnings without contract coverage**: Rejected because it leaves a high-risk requirement under-tested.
+
+## Decision 12: Constrain the operator launch workflow to five manual actions
+
+- **Decision**: The deployment design treats the manual pre-launch workflow as exactly five operator actions: publish artifact, confirm ACM issuance, confirm Route 53 authority, gather secret references, and launch the stack with parameters.
+- **Rationale**: Success criterion SC-005 needs a concrete workflow boundary to be measurable. Enumerating the five actions keeps the deployment guide honest and lets tasks and tests verify the limit directly.
+- **Alternatives considered**:
+  - **Count manual actions informally**: Rejected because it makes SC-005 difficult to validate.
+  - **Ignore the action count and optimize only for technical correctness**: Rejected because SC-005 is a user-facing outcome, not an optional note.

--- a/specs/011-aws-cloudformation/spec.md
+++ b/specs/011-aws-cloudformation/spec.md
@@ -3,14 +3,14 @@
 **Feature Branch**: `[011-aws-cloudformation]`  
 **Created**: 2026-04-06  
 **Status**: Draft  
-**Input**: User description: "create aws cloud formation template for this web application. Use an ec2 instance for the web app. Use dynamodb for the persistence. Use the domain name payslip.co.za for the load balancer and ec2 instance. Try to use as much of the free tier as you can. Ensure dynamodb is regularly backed up"
+**Input**: User description: "create aws cloud formation template for this web application. Use an ec2 instance for the web app. Use dynamodb for the persistence. Use the domain name payslip4all.co.za for the load balancer and ec2 instance. Try to use as much of the free tier as you can. Ensure dynamodb is regularly backed up"
 
 ## Architecture & TDD Alignment *(mandatory for Payslip4All)*
 
 - **Domain**: No new business rules are introduced; the deployment must preserve existing Payslip4All behaviour.
 - **Application**: Any deployment-specific configuration exposed to the app must remain environment-driven and not change core use-case behaviour.
 - **Infrastructure**: This feature provisions hosting, networking, DNS, persistence, observability, and backup capabilities for a single deployed environment.
-- **Web**: The web application must be reachable through the public payslip.co.za entry point without requiring end users to know the instance address.
+- **Web**: The web application must be reachable through the public payslip4all.co.za entry point without requiring end users to know the instance address.
 - **TDD Alignment**: Each functional requirement below is expressed as observable deployment behaviour so implementation can be driven by failing infrastructure, configuration, and startup acceptance tests first.
 
 ### User Story 1 - Deploy a working environment (Priority: P1)
@@ -28,18 +28,18 @@ As an operator, I want a single deployment template that stands up the web appli
 
 ---
 
-### User Story 2 - Publish the application on payslip.co.za (Priority: P2)
+### User Story 2 - Publish the application on payslip4all.co.za (Priority: P2)
 
-As an operator, I want the deployed application exposed through payslip.co.za with consistent environment naming so I can direct users to a stable public address and identify the corresponding compute resource easily.
+As an operator, I want the deployed application exposed through payslip4all.co.za with consistent environment naming so I can direct users to a stable public address and identify the corresponding compute resource easily.
 
 **Why this priority**: Public reachability and clear operational naming are essential for going live and supporting the environment after deployment.
 
-**Independent Test**: Complete a deployment with domain inputs, then confirm that users can browse to payslip.co.za successfully and operators can identify the associated server using payslip.co.za-based naming metadata.
+**Independent Test**: Complete a deployment with domain inputs, then confirm that users can browse to payslip4all.co.za successfully and operators can identify the associated server using payslip4all.co.za-based naming metadata.
 
 **Acceptance Scenarios**:
 
-1. **Given** the operator supplies the required domain prerequisites, **When** the deployment finishes, **Then** incoming web traffic resolves through payslip.co.za to the public application entry point.
-2. **Given** an operator is reviewing the running environment, **When** they inspect the deployed compute resource, **Then** its name or identifying metadata clearly associates it with payslip.co.za.
+1. **Given** the operator supplies the required domain prerequisites, **When** the deployment finishes, **Then** incoming web traffic resolves through payslip4all.co.za to the public application entry point.
+2. **Given** an operator is reviewing the running environment, **When** they inspect the deployed compute resource, **Then** its name or identifying metadata clearly associates it with payslip4all.co.za.
 
 ---
 
@@ -60,7 +60,7 @@ As an operator, I want the DynamoDB-backed persistence layer protected by automa
 
 ### Edge Cases
 
-- What happens when the operator cannot validate ownership of payslip.co.za or provide the required domain prerequisites before deployment?
+- What happens when the operator cannot validate ownership of payslip4all.co.za or provide the required domain prerequisites before deployment?
 - How does the deployment behave when a chosen region cannot satisfy the lowest-cost default capacity or free-tier-eligible resource assumptions?
 - What happens when the web server instance becomes unhealthy while the persistence layer remains healthy?
 - How is restore handled so recovered DynamoDB data does not overwrite the live environment unintentionally during an operator-led recovery exercise?
@@ -72,8 +72,8 @@ As an operator, I want the DynamoDB-backed persistence layer protected by automa
 - **FR-001**: The system MUST provide a single AWS deployment template that provisions all mandatory infrastructure required to run one Payslip4All web environment.
 - **FR-002**: The deployment MUST host the web application on one EC2 instance behind a public load-balanced entry point.
 - **FR-003**: The deployment MUST use DynamoDB as the persistence store for the application environment created by this feature.
-- **FR-004**: The deployment MUST expose the application to end users through payslip.co.za as the primary public address.
-- **FR-005**: The deployment MUST apply payslip.co.za-based naming or tags to the EC2 instance so operators can identify the instance that serves that environment.
+- **FR-004**: The deployment MUST expose the application to end users through payslip4all.co.za as the primary public address.
+- **FR-005**: The deployment MUST apply payslip4all.co.za-based naming or tags to the EC2 instance so operators can identify the instance that serves that environment.
 - **FR-006**: The deployment MUST externalize environment-specific inputs, including domain prerequisites, secret references, operator access allowlists, and environment naming values, so they are not hardcoded in the template.
 - **FR-007**: The public entry point MUST support secure user access and redirect non-secure traffic to the secure endpoint.
 - **FR-008**: The load-balanced entry point MUST use health-based routing so unhealthy web instances do not continue receiving end-user traffic.
@@ -87,8 +87,8 @@ As an operator, I want the DynamoDB-backed persistence layer protected by automa
 ### Key Entities *(include if feature involves data)*
 
 - **Deployment Stack**: The complete infrastructure definition for one Payslip4All environment, including hosting, networking, DNS integration, persistence, observability, and recovery settings.
-- **Public Entry Point**: The user-facing endpoint for payslip.co.za that receives web traffic, enforces secure access, and routes requests to the running application instance.
-- **Application Instance**: The single EC2-hosted web server identified with payslip.co.za-based metadata and treated as replaceable compute.
+- **Public Entry Point**: The user-facing endpoint for payslip4all.co.za that receives web traffic, enforces secure access, and routes requests to the running application instance.
+- **Application Instance**: The single EC2-hosted web server identified with payslip4all.co.za-based metadata and treated as replaceable compute.
 - **Persistence Store**: The DynamoDB-backed application data boundary whose lifecycle is independent from the application instance.
 - **Backup Protection Policy**: The automated recovery configuration that defines how DynamoDB data is protected and restored.
 
@@ -97,14 +97,14 @@ As an operator, I want the DynamoDB-backed persistence layer protected by automa
 ### Measurable Outcomes
 
 - **SC-001**: An operator can launch a working environment from the provided template in 45 minutes or less after required AWS account, domain, and secret prerequisites are ready.
-- **SC-002**: Users can reach the deployed application through payslip.co.za and receive the first complete page load within 10 seconds during a standard smoke test.
+- **SC-002**: Users can reach the deployed application through payslip4all.co.za and receive the first complete page load within 10 seconds during a standard smoke test.
 - **SC-003**: Replacing the web server instance results in no loss of DynamoDB-backed application data for 100% of data created before the replacement event.
 - **SC-004**: Operators can complete a DynamoDB restore exercise from automated backups within 60 minutes without rebuilding the public entry point.
 - **SC-005**: The documented operator workflow from prepared prerequisites to submitting the deployment requires no more than five manual actions.
 
 ## Assumptions
 
-- The public user-facing address is payslip.co.za, while the EC2 instance uses payslip.co.za-derived naming metadata for identification rather than a second public DNS endpoint on the same apex domain.
+- The public user-facing address is payslip4all.co.za, while the EC2 instance uses payslip4all.co.za-derived naming metadata for identification rather than a second public DNS endpoint on the same apex domain.
 - The deployment targets a single-environment, single-instance footprint optimized for low cost rather than high availability across multiple compute instances.
 - Required AWS account prerequisites such as domain ownership, certificate validation, and secret values are available before template execution begins.
 - Daily automated recoverability is an acceptable minimum interpretation of "regularly backed up" for DynamoDB in this feature.

--- a/specs/011-aws-cloudformation/spec.md
+++ b/specs/011-aws-cloudformation/spec.md
@@ -1,0 +1,111 @@
+# Feature Specification: AWS CloudFormation Deployment
+
+**Feature Branch**: `[011-aws-cloudformation]`  
+**Created**: 2026-04-06  
+**Status**: Draft  
+**Input**: User description: "create aws cloud formation template for this web application. Use an ec2 instance for the web app. Use dynamodb for the persistence. Use the domain name payslip.co.za for the load balancer and ec2 instance. Try to use as much of the free tier as you can. Ensure dynamodb is regularly backed up"
+
+## Architecture & TDD Alignment *(mandatory for Payslip4All)*
+
+- **Domain**: No new business rules are introduced; the deployment must preserve existing Payslip4All behaviour.
+- **Application**: Any deployment-specific configuration exposed to the app must remain environment-driven and not change core use-case behaviour.
+- **Infrastructure**: This feature provisions hosting, networking, DNS, persistence, observability, and backup capabilities for a single deployed environment.
+- **Web**: The web application must be reachable through the public payslip.co.za entry point without requiring end users to know the instance address.
+- **TDD Alignment**: Each functional requirement below is expressed as observable deployment behaviour so implementation can be driven by failing infrastructure, configuration, and startup acceptance tests first.
+
+### User Story 1 - Deploy a working environment (Priority: P1)
+
+As an operator, I want a single deployment template that stands up the web application with its required AWS resources so I can launch a working environment consistently without building infrastructure by hand.
+
+**Why this priority**: A reliable first deployment is the minimum value of this feature. Without it, the rest of the hosting, domain, and backup requirements cannot be delivered.
+
+**Independent Test**: Launch the stack in a new AWS account or environment with the required inputs and confirm the application starts successfully with persistence configured and no manual creation of core infrastructure resources.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator has the required AWS account inputs, **When** they deploy the template, **Then** the system provisions the web hosting environment and persistence layer needed for one working Payslip4All instance without hand-creating core AWS resources.
+2. **Given** the deployment completes successfully, **When** the operator replaces the web server instance through the same template, **Then** the shared infrastructure remains intact and application data is preserved.
+
+---
+
+### User Story 2 - Publish the application on payslip.co.za (Priority: P2)
+
+As an operator, I want the deployed application exposed through payslip.co.za with consistent environment naming so I can direct users to a stable public address and identify the corresponding compute resource easily.
+
+**Why this priority**: Public reachability and clear operational naming are essential for going live and supporting the environment after deployment.
+
+**Independent Test**: Complete a deployment with domain inputs, then confirm that users can browse to payslip.co.za successfully and operators can identify the associated server using payslip.co.za-based naming metadata.
+
+**Acceptance Scenarios**:
+
+1. **Given** the operator supplies the required domain prerequisites, **When** the deployment finishes, **Then** incoming web traffic resolves through payslip.co.za to the public application entry point.
+2. **Given** an operator is reviewing the running environment, **When** they inspect the deployed compute resource, **Then** its name or identifying metadata clearly associates it with payslip.co.za.
+
+---
+
+### User Story 3 - Protect DynamoDB data with automated recovery (Priority: P3)
+
+As an operator, I want the DynamoDB-backed persistence layer protected by automated backups so I can recover application data after an operational failure without rebuilding the entire environment.
+
+**Why this priority**: Persistent business data must remain recoverable even in a low-cost deployment, and this protection is explicitly required for the production environment.
+
+**Independent Test**: Deploy the stack, create representative application data, verify automated backup protection is enabled, and perform a restore exercise that recovers the saved data to a recoverable target.
+
+**Acceptance Scenarios**:
+
+1. **Given** the environment is running, **When** data is written to the persistence layer, **Then** automated backup protection covers that data without requiring manual backup steps after deployment.
+2. **Given** the operator needs to recover data, **When** they perform a restore using the defined backup mechanism, **Then** the data can be recovered without rebuilding the public entry point or recreating the application manually.
+
+---
+
+### Edge Cases
+
+- What happens when the operator cannot validate ownership of payslip.co.za or provide the required domain prerequisites before deployment?
+- How does the deployment behave when a chosen region cannot satisfy the lowest-cost default capacity or free-tier-eligible resource assumptions?
+- What happens when the web server instance becomes unhealthy while the persistence layer remains healthy?
+- How is restore handled so recovered DynamoDB data does not overwrite the live environment unintentionally during an operator-led recovery exercise?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a single AWS deployment template that provisions all mandatory infrastructure required to run one Payslip4All web environment.
+- **FR-002**: The deployment MUST host the web application on one EC2 instance behind a public load-balanced entry point.
+- **FR-003**: The deployment MUST use DynamoDB as the persistence store for the application environment created by this feature.
+- **FR-004**: The deployment MUST expose the application to end users through payslip.co.za as the primary public address.
+- **FR-005**: The deployment MUST apply payslip.co.za-based naming or tags to the EC2 instance so operators can identify the instance that serves that environment.
+- **FR-006**: The deployment MUST externalize environment-specific inputs, including domain prerequisites, secret references, operator access allowlists, and environment naming values, so they are not hardcoded in the template.
+- **FR-007**: The public entry point MUST support secure user access and redirect non-secure traffic to the secure endpoint.
+- **FR-008**: The load-balanced entry point MUST use health-based routing so unhealthy web instances do not continue receiving end-user traffic.
+- **FR-009**: The deployment MUST include operator-visible health and deployment signals, including deployment outputs that identify the running environment, target-health visibility for the active web instance, and a health endpoint that confirms public application responsiveness.
+- **FR-010**: The default deployment footprint MUST minimize ongoing cost by preferring free-tier-eligible or lowest-cost practical defaults unless a higher-cost option is required to satisfy another functional requirement.
+- **FR-011**: The deployment MUST allow the EC2 instance to be replaced or recreated through the same template without losing DynamoDB data or requiring recreation of shared infrastructure such as routing and persistence resources.
+- **FR-012**: The DynamoDB persistence layer MUST have automated backup protection enabled with recoverability from at least one recovery point per day.
+- **FR-013**: The feature MUST document the operator steps and constraints for restoring DynamoDB data from backups.
+- **FR-014**: The feature MUST document any cost-related exceptions where the domain, load balancing, or backup requirements cannot remain fully within AWS free-tier allowances.
+
+### Key Entities *(include if feature involves data)*
+
+- **Deployment Stack**: The complete infrastructure definition for one Payslip4All environment, including hosting, networking, DNS integration, persistence, observability, and recovery settings.
+- **Public Entry Point**: The user-facing endpoint for payslip.co.za that receives web traffic, enforces secure access, and routes requests to the running application instance.
+- **Application Instance**: The single EC2-hosted web server identified with payslip.co.za-based metadata and treated as replaceable compute.
+- **Persistence Store**: The DynamoDB-backed application data boundary whose lifecycle is independent from the application instance.
+- **Backup Protection Policy**: The automated recovery configuration that defines how DynamoDB data is protected and restored.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An operator can launch a working environment from the provided template in 45 minutes or less after required AWS account, domain, and secret prerequisites are ready.
+- **SC-002**: Users can reach the deployed application through payslip.co.za and receive the first complete page load within 10 seconds during a standard smoke test.
+- **SC-003**: Replacing the web server instance results in no loss of DynamoDB-backed application data for 100% of data created before the replacement event.
+- **SC-004**: Operators can complete a DynamoDB restore exercise from automated backups within 60 minutes without rebuilding the public entry point.
+- **SC-005**: The documented operator workflow from prepared prerequisites to submitting the deployment requires no more than five manual actions.
+
+## Assumptions
+
+- The public user-facing address is payslip.co.za, while the EC2 instance uses payslip.co.za-derived naming metadata for identification rather than a second public DNS endpoint on the same apex domain.
+- The deployment targets a single-environment, single-instance footprint optimized for low cost rather than high availability across multiple compute instances.
+- Required AWS account prerequisites such as domain ownership, certificate validation, and secret values are available before template execution begins.
+- Daily automated recoverability is an acceptable minimum interpretation of "regularly backed up" for DynamoDB in this feature.
+- The five manual operator actions counted for SC-005 are publishing the deployable artifact, confirming certificate readiness, confirming DNS authority, gathering external secret references, and submitting the deployment.

--- a/specs/011-aws-cloudformation/tasks.md
+++ b/specs/011-aws-cloudformation/tasks.md
@@ -9,7 +9,7 @@
 **Organization**: Tasks are grouped by user story priority so each deployment slice can be implemented, tested, and validated independently.
 
 **Gap resolutions encoded in this task list**:
-- **FR-002 sequencing fix**: ALB + target group + health-based routing are provisioned in US1 (working environment) so the app is behind a load balancer from day one; Route 53 + ACM + public `payslip.co.za` access are added in US2. MVP no longer promises public reachability.
+- **FR-002 sequencing fix**: ALB + target group + health-based routing are provisioned in US1 (working environment) so the app is behind a load balancer from day one; Route 53 + ACM + public `payslip4all.co.za` access are added in US2. MVP no longer promises public reachability.
 - **FR-006 allowlist coverage**: Explicit test (T012) verifies `AllowedSshCidr` is a template parameter wired to the security group ingress rule with no hardcoded operator-access range.
 - **FR-009 signal inventory coverage**: Explicit test (T005) verifies the complete required output set — `ApplicationUrl`, `InstanceId`, `LoadBalancerArn`, security-group identifiers, and backup mode — is present in the template before implementation.
 - **FR-011 EC2 replacement coverage**: Explicit test (T013) verifies the CloudFormation template's resource structure keeps DynamoDB, networking, and ALB resources independent of the EC2 instance lifecycle so replacement does not destroy application data or shared infrastructure.
@@ -52,7 +52,7 @@
 
 ## Phase 3: User Story 1 - Deploy a working environment (Priority: P1) 🎯 MVP
 
-**Goal**: Give operators one CloudFormation-driven path to launch a working Payslip4All environment on EC2 behind an ALB with DynamoDB-backed persistence. Public `payslip.co.za` reachability is NOT required at this stage (see US2).
+**Goal**: Give operators one CloudFormation-driven path to launch a working Payslip4All environment on EC2 behind an ALB with DynamoDB-backed persistence. Public `payslip4all.co.za` reachability is NOT required at this stage (see US2).
 
 **Independent Test**: Launch the stack with required inputs and confirm the EC2-hosted app starts successfully, the ALB target is healthy, DynamoDB tables are provisioned, and no core AWS resources were created by hand. Public DNS reachability is out of scope for this story.
 
@@ -75,23 +75,23 @@
 
 ---
 
-## Phase 4: User Story 2 - Publish the application on payslip.co.za (Priority: P2)
+## Phase 4: User Story 2 - Publish the application on payslip4all.co.za (Priority: P2)
 
-**Goal**: Expose the deployed application through `payslip.co.za` with secure public routing and payslip.co.za-derived operational naming. This phase extends the US1 ALB with HTTPS, Route 53, and ACM integration.
+**Goal**: Expose the deployed application through `payslip4all.co.za` with secure public routing and payslip4all.co.za-derived operational naming. This phase extends the US1 ALB with HTTPS, Route 53, and ACM integration.
 
-**Independent Test**: Complete the deployment with domain prerequisites and confirm `https://payslip.co.za` resolves to the ALB-backed application, HTTP traffic redirects to HTTPS, and the EC2 instance is identifiable through payslip.co.za-based metadata.
+**Independent Test**: Complete the deployment with domain prerequisites and confirm `https://payslip4all.co.za` resolves to the ALB-backed application, HTTP traffic redirects to HTTPS, and the EC2 instance is identifiable through payslip4all.co.za-based metadata.
 
 ### Tests for User Story 2 (REQUIRED — TDD, confirm FAILING before T021)
 
-- [X] T019 [P] [US2] Add failing template tests for HTTPS ALB listener with ACM certificate reference, HTTP-to-HTTPS redirect rule, Route 53 alias record pointing `payslip.co.za` at the ALB, and payslip.co.za-derived `Name` tag on the EC2 instance and ALB in `tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs`
+- [X] T019 [P] [US2] Add failing template tests for HTTPS ALB listener with ACM certificate reference, HTTP-to-HTTPS redirect rule, Route 53 alias record pointing `payslip4all.co.za` at the ALB, and payslip4all.co.za-derived `Name` tag on the EC2 instance and ALB in `tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs`
 - [X] T020 [P] [US2] Add failing documentation tests for DNS ownership confirmation prerequisite, ACM certificate issuance prerequisite, and non-free-tier cost disclosure for ALB and Route 53 in `tests/Payslip4All.Web.Tests/Infrastructure/AwsDeploymentDocumentationTests.cs`
 
 ### Implementation for User Story 2
 
-- [X] T021 [US2] Implement HTTPS ALB listener with ACM certificate attachment, HTTP-to-HTTPS redirect rule, Route 53 alias record for `payslip.co.za`, and payslip.co.za-derived instance and load-balancer tags in `infra/aws/cloudformation/payslip4all-web.yaml`
+- [X] T021 [US2] Implement HTTPS ALB listener with ACM certificate attachment, HTTP-to-HTTPS redirect rule, Route 53 alias record for `payslip4all.co.za`, and payslip4all.co.za-derived instance and load-balancer tags in `infra/aws/cloudformation/payslip4all-web.yaml`
 - [X] T022 [US2] Document public-domain setup, HTTPS behaviour, operator-visible resource naming, and non-free-tier cost exceptions in `infra/aws/cloudformation/README.md` and `README.md`
 
-**Checkpoint**: US2 is complete when `https://payslip.co.za` resolves to the application and operators can identify the EC2 instance from payslip.co.za-derived metadata.
+**Checkpoint**: US2 is complete when `https://payslip4all.co.za` resolves to the application and operators can identify the EC2 instance from payslip4all.co.za-derived metadata.
 
 ---
 
@@ -179,7 +179,7 @@ Task T014: "Launch prerequisites and runtime environment variables"
 
 ```bash
 # Launch the US2 failing tests together:
-Task T019: "HTTPS listener, HTTP redirect, Route 53 alias, payslip.co.za tags — AwsCloudFormationTemplateTests.cs"
+Task T019: "HTTPS listener, HTTP redirect, Route 53 alias, payslip4all.co.za tags — AwsCloudFormationTemplateTests.cs"
 Task T020: "ACM prerequisites, DNS ownership, cost disclosures — AwsDeploymentDocumentationTests.cs"
 ```
 
@@ -210,7 +210,7 @@ Task T024: "Backup IAM permissions, backup-mode output, restore runbook content 
 
 1. Finish Setup + Foundational → deployment contract, runtime expectations, and signal inventory locked
 2. Deliver **US1** → core launchable AWS environment with ALB and DynamoDB, five-step workflow verified
-3. Deliver **US2** → public `payslip.co.za` entry point, HTTPS, Route 53, operational naming
+3. Deliver **US2** → public `payslip4all.co.za` entry point, HTTPS, Route 53, operational naming
 4. Deliver **US3** → automated DynamoDB PITR protection and documented restore drill
 5. Finish with **Polish** to align docs and run full validation suite
 
@@ -230,7 +230,7 @@ Task T024: "Backup IAM permissions, backup-mode output, restore runbook content 
 - `[P]` tasks can run in parallel because they target separate files or non-overlapping test methods
 - All user-story tasks carry story labels and exact file paths for traceability
 - Each story is independently testable from the operator's perspective before subsequent stories begin
-- FR-002 is fully satisfied at US2 completion (public load-balanced entry on `payslip.co.za`); US1 satisfies the load-balancer infrastructure prerequisite without requiring public DNS
+- FR-002 is fully satisfied at US2 completion (public load-balanced entry on `payslip4all.co.za`); US1 satisfies the load-balancer infrastructure prerequisite without requiring public DNS
 - FR-006, FR-009, FR-011, and SC-005 each have dedicated test tasks (T012, T005, T013, T015) to ensure they are verified before implementation is marked complete
 - The CloudFormation template and deployment README are shared assets across stories; parallel work must focus on isolated test methods and separate code files first to avoid merge conflicts
 - Do not auto-commit; the Manual Test Gate must be presented and approved before any `git commit`, `git merge`, or `git push`

--- a/specs/011-aws-cloudformation/tasks.md
+++ b/specs/011-aws-cloudformation/tasks.md
@@ -1,0 +1,236 @@
+# Tasks: AWS CloudFormation Deployment
+
+**Input**: Design documents from `specs/011-aws-cloudformation/`  
+**Required inputs**: `specs/011-aws-cloudformation/plan.md`, `specs/011-aws-cloudformation/spec.md`  
+**Additional inputs used**: `specs/011-aws-cloudformation/research.md`, `specs/011-aws-cloudformation/data-model.md`, `specs/011-aws-cloudformation/contracts/cloudformation-deployment-contract.md`, `specs/011-aws-cloudformation/quickstart.md`
+
+**Tests**: TDD is required in this repository (constitution Principle I). Each user-story phase starts with failing xUnit tests that lock CloudFormation template structure, startup behaviour, and DynamoDB backup behaviour before any implementation begins. Test tasks are non-optional.
+
+**Organization**: Tasks are grouped by user story priority so each deployment slice can be implemented, tested, and validated independently.
+
+**Gap resolutions encoded in this task list**:
+- **FR-002 sequencing fix**: ALB + target group + health-based routing are provisioned in US1 (working environment) so the app is behind a load balancer from day one; Route 53 + ACM + public `payslip.co.za` access are added in US2. MVP no longer promises public reachability.
+- **FR-006 allowlist coverage**: Explicit test (T012) verifies `AllowedSshCidr` is a template parameter wired to the security group ingress rule with no hardcoded operator-access range.
+- **FR-009 signal inventory coverage**: Explicit test (T005) verifies the complete required output set — `ApplicationUrl`, `InstanceId`, `LoadBalancerArn`, security-group identifiers, and backup mode — is present in the template before implementation.
+- **FR-011 EC2 replacement coverage**: Explicit test (T013) verifies the CloudFormation template's resource structure keeps DynamoDB, networking, and ALB resources independent of the EC2 instance lifecycle so replacement does not destroy application data or shared infrastructure.
+- **SC-005 workflow validation**: Explicit documentation test (T015) asserts that `infra/aws/cloudformation/README.md` enumerates exactly five manual pre-launch actions matching the contract-defined steps.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Task can run in parallel with other tasks in the same phase (different files, no blocking dependency)
+- **[Story]**: Present only in user-story phases as `[US1]`, `[US2]`, `[US3]`
+- Every task includes exact file path(s)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Prepare the CloudFormation workspace, bootstrap assets, and dedicated deployment test files.
+
+- [X] T001 Create the deployment asset scaffold in `infra/aws/cloudformation/payslip4all-web.yaml`, `infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh`, and `infra/aws/cloudformation/README.md`
+- [X] T002 [P] Create CloudFormation template and deployment-document test files in `tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs` and `tests/Payslip4All.Web.Tests/Infrastructure/AwsDeploymentDocumentationTests.cs`
+- [X] T003 [P] Create AWS startup and DynamoDB backup test files in `tests/Payslip4All.Web.Tests/Startup/AwsDeploymentStartupTests.cs` and `tests/Payslip4All.Infrastructure.Tests/Persistence/DynamoDB/DynamoDbBackupProtectionTests.cs`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Lock the shared deployment assumptions every user story depends on before story-specific implementation begins.
+
+**⚠️ CRITICAL**: All failing tests in this phase must be confirmed failing before user-story work starts.
+
+- [X] T004 [P] Add failing template-contract tests for all required CloudFormation parameters (including externalized inputs from the contract) and the base compute and DynamoDB deployment defaults in `tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs`
+- [X] T005 [P] Add failing template output tests asserting the complete FR-009 operator-visible signal inventory: `ApplicationUrl`, `InstanceId`, `LoadBalancerArn`, at least two security-group identifier outputs, and a backup-mode output in `tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs`
+- [X] T006 [P] Add failing startup tests for the load-balancer health endpoint registration and AWS DynamoDB environment binding (`PERSISTENCE_PROVIDER`, `DYNAMODB_REGION`, `DYNAMODB_TABLE_PREFIX`) in `tests/Payslip4All.Web.Tests/Startup/AwsDeploymentStartupTests.cs`
+- [X] T007 [P] Add failing backup-protection tests for point-in-time recovery enablement and restore-to-new-table safety in `tests/Payslip4All.Infrastructure.Tests/Persistence/DynamoDB/DynamoDbBackupProtectionTests.cs`
+- [X] T008 Implement the reusable deployment health endpoint and register it in startup in `src/Payslip4All.Web/Endpoints/HealthEndpoint.cs` and `src/Payslip4All.Web/Program.cs`
+- [X] T009 Create the shared CloudFormation parameter block, output skeleton (covering the full FR-009 signal set), and bootstrap environment variable rendering in `infra/aws/cloudformation/payslip4all-web.yaml` and `infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh`
+
+**Checkpoint**: Shared deployment tests, health endpoint, and base infrastructure skeleton are ready for user-story implementation.
+
+---
+
+## Phase 3: User Story 1 - Deploy a working environment (Priority: P1) 🎯 MVP
+
+**Goal**: Give operators one CloudFormation-driven path to launch a working Payslip4All environment on EC2 behind an ALB with DynamoDB-backed persistence. Public `payslip.co.za` reachability is NOT required at this stage (see US2).
+
+**Independent Test**: Launch the stack with required inputs and confirm the EC2-hosted app starts successfully, the ALB target is healthy, DynamoDB tables are provisioned, and no core AWS resources were created by hand. Public DNS reachability is out of scope for this story.
+
+### Tests for User Story 1 (REQUIRED — TDD, confirm FAILING before T016)
+
+- [X] T010 [P] [US1] Add failing template tests for VPC, public subnets, EC2 security group, IAM instance profile, and single EC2 instance resource structure in `tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs`
+- [X] T011 [P] [US1] Add failing template tests for ALB resource, target group, HTTP listener, and health-check configuration confirming the app is behind a load-balanced entry point (FR-002 base) without Route 53 or ACM in `tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs`
+- [X] T012 [P] [US1] Add failing template test for FR-006 operator access allowlist: verify `AllowedSshCidr` is a declared parameter wired to the EC2 security group SSH ingress rule and that no operator-access CIDR range is hardcoded in the template in `tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs`
+- [X] T013 [P] [US1] Add failing template test for FR-011 EC2 replacement safety: verify DynamoDB-related resources, ALB, and networking resources are declared independently of the EC2 instance such that replacing or recreating the instance does not trigger deletion of shared infrastructure or application data in `tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs`
+- [X] T014 [P] [US1] Add failing documentation tests for operator launch prerequisites and required runtime environment variables (`PERSISTENCE_PROVIDER`, `DYNAMODB_REGION`, `DYNAMODB_TABLE_PREFIX`) in `tests/Payslip4All.Web.Tests/Infrastructure/AwsDeploymentDocumentationTests.cs`
+- [X] T015 [US1] Add failing documentation test for SC-005: assert that `infra/aws/cloudformation/README.md` enumerates exactly five manual pre-launch actions matching the contract-defined steps (publish artifact, confirm ACM issuance, confirm Route 53 authority, gather secret references, launch stack) in `tests/Payslip4All.Web.Tests/Infrastructure/AwsDeploymentDocumentationTests.cs`
+
+### Implementation for User Story 1
+
+- [X] T016 [US1] Implement VPC, public subnets, security groups, IAM instance profile, EC2 instance, ALB, target group, HTTP listener, and health-based routing resources in `infra/aws/cloudformation/payslip4all-web.yaml`
+- [X] T017 [US1] Implement the instance bootstrap flow that installs and starts Payslip4All with `PERSISTENCE_PROVIDER=dynamodb`, `DYNAMODB_REGION`, and `DYNAMODB_TABLE_PREFIX` and no hardcoded reusable secrets in `infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh`
+- [X] T018 [US1] Document stack launch inputs, secret reference patterns, the five-action pre-launch workflow enumeration, and first-deploy steps in `infra/aws/cloudformation/README.md`
+
+**Checkpoint**: US1 is complete when operators can launch one working EC2 + ALB + DynamoDB environment, the ALB target is healthy, and the five-step launch workflow is documented.
+
+---
+
+## Phase 4: User Story 2 - Publish the application on payslip.co.za (Priority: P2)
+
+**Goal**: Expose the deployed application through `payslip.co.za` with secure public routing and payslip.co.za-derived operational naming. This phase extends the US1 ALB with HTTPS, Route 53, and ACM integration.
+
+**Independent Test**: Complete the deployment with domain prerequisites and confirm `https://payslip.co.za` resolves to the ALB-backed application, HTTP traffic redirects to HTTPS, and the EC2 instance is identifiable through payslip.co.za-based metadata.
+
+### Tests for User Story 2 (REQUIRED — TDD, confirm FAILING before T021)
+
+- [X] T019 [P] [US2] Add failing template tests for HTTPS ALB listener with ACM certificate reference, HTTP-to-HTTPS redirect rule, Route 53 alias record pointing `payslip.co.za` at the ALB, and payslip.co.za-derived `Name` tag on the EC2 instance and ALB in `tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs`
+- [X] T020 [P] [US2] Add failing documentation tests for DNS ownership confirmation prerequisite, ACM certificate issuance prerequisite, and non-free-tier cost disclosure for ALB and Route 53 in `tests/Payslip4All.Web.Tests/Infrastructure/AwsDeploymentDocumentationTests.cs`
+
+### Implementation for User Story 2
+
+- [X] T021 [US2] Implement HTTPS ALB listener with ACM certificate attachment, HTTP-to-HTTPS redirect rule, Route 53 alias record for `payslip.co.za`, and payslip.co.za-derived instance and load-balancer tags in `infra/aws/cloudformation/payslip4all-web.yaml`
+- [X] T022 [US2] Document public-domain setup, HTTPS behaviour, operator-visible resource naming, and non-free-tier cost exceptions in `infra/aws/cloudformation/README.md` and `README.md`
+
+**Checkpoint**: US2 is complete when `https://payslip.co.za` resolves to the application and operators can identify the EC2 instance from payslip.co.za-derived metadata.
+
+---
+
+## Phase 5: User Story 3 - Protect DynamoDB data with automated recovery (Priority: P3)
+
+**Goal**: Ensure the DynamoDB-backed deployment has automated point-in-time recovery protection on all application tables and a documented restore path that does not require rebuilding the public entry point.
+
+**Independent Test**: Confirm PITR is enabled for every Payslip4All DynamoDB table after stack launch, verify the restore drill creates a new target table without touching the live environment, and validate the runbook steps produce the expected outcome.
+
+### Tests for User Story 3 (REQUIRED — TDD, confirm FAILING before T025)
+
+- [X] T023 [P] [US3] Add failing infrastructure tests for PITR enablement on every Payslip4All DynamoDB table and for restore-to-new-table behaviour that avoids overwriting live data in `tests/Payslip4All.Infrastructure.Tests/Persistence/DynamoDB/DynamoDbBackupProtectionTests.cs`
+- [X] T024 [P] [US3] Add failing template and documentation tests for backup-related IAM permissions on the instance role, the FR-009 backup-mode output, and restore runbook content (including the safe non-live-target restore path) in `tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs` and `tests/Payslip4All.Web.Tests/Infrastructure/AwsDeploymentDocumentationTests.cs`
+
+### Implementation for User Story 3
+
+- [X] T025 [US3] Implement the `DynamoDbBackupProtectionHostedService` that enables PITR on all application tables at startup and register it through `DynamoDbServiceExtensions` alongside the existing `DynamoDbTableProvisioner` in `src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbBackupProtectionHostedService.cs`, `src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbServiceExtensions.cs`, and `src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbTableProvisioner.cs`
+- [X] T026 [US3] Add DynamoDB backup IAM permissions (`dynamodb:UpdateContinuousBackups`, `dynamodb:DescribeContinuousBackups`, `dynamodb:RestoreTableToPointInTime`) and the backup-mode CloudFormation output to the instance role and Outputs section in `infra/aws/cloudformation/payslip4all-web.yaml`
+- [X] T027 [US3] Document automated backup behaviour, operator-led restore steps (restore to non-live table, validate, promote), recovery validation criteria, and the 60-minute restore drill target in `infra/aws/cloudformation/README.md`
+
+**Checkpoint**: US3 is complete when PITR is enabled on all application tables, operators can execute a restore drill into a new table, and the runbook is verified by the documentation tests.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Align root documentation, operational guidance, and full-suite validation across all stories.
+
+- [X] T028 [P] Add final deployment entry-point references and CloudFormation usage notes to `README.md` and `infra/aws/cloudformation/README.md`
+- [X] T029 [P] Align health-check path, forwarded-header handling, and operational logging configuration for a behind-ALB deployment in `src/Payslip4All.Web/Program.cs` and `infra/aws/cloudformation/README.md`
+- [X] T030 Run the full targeted deployment validation suites and the quickstart walkthrough in `tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs`, `tests/Payslip4All.Web.Tests/Infrastructure/AwsDeploymentDocumentationTests.cs`, `tests/Payslip4All.Web.Tests/Startup/AwsDeploymentStartupTests.cs`, `tests/Payslip4All.Infrastructure.Tests/Persistence/DynamoDB/DynamoDbBackupProtectionTests.cs`, and `specs/011-aws-cloudformation/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion; blocks all user stories
+- **User Story 1 (Phase 3)**: Depends on Foundational completion; MVP deployment slice — no public domain required
+- **User Story 2 (Phase 4)**: Depends on Foundational completion; extends the US1 ALB with public domain and HTTPS; shares `payslip4all-web.yaml` and README with US1 so sequence after US1 to avoid merge conflicts
+- **User Story 3 (Phase 5)**: Depends on Foundational completion; shares DynamoDB infrastructure and deployment docs; sequence after US1 to avoid conflicting edits to the same files
+- **Polish (Phase 6)**: Depends on all required user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: No dependency on other stories after Foundational; delivers EC2 + ALB + DynamoDB working environment
+- **US2 (P2)**: Extends US1's ALB with Route 53 and ACM; must not merge `payslip4all-web.yaml` changes until US1 implementation tasks (T016–T018) are complete
+- **US3 (P3)**: Extends the instance IAM role and adds a hosted service; must not merge IAM or startup changes until US1 implementation tasks (T016–T017) are complete
+
+### Within Each User Story
+
+- Write the failing tests first (TDD gate: confirm FAIL before writing implementation files)
+- Lock CloudFormation resource, signal, and security behaviour in tests before editing deployment assets
+- Implement infrastructure and application changes before documentation updates within the story
+- Run the story's targeted tests to confirm they pass before moving to the next story
+- **Manual Test Gate (constitution Principle VI)**: After each implementation task, present the gate prompt to the engineer and await explicit `approve` before any `git commit`, `git merge`, or `git push`
+
+### Parallel Opportunities
+
+- `T002` and `T003` can run in parallel (different test files)
+- Within **Phase 2**: `T004`, `T005`, `T006`, and `T007` can run in parallel (different test files and concerns)
+- Within **US1 tests**: `T010`, `T011`, `T012`, `T013`, and `T014` can run in parallel (same test file but different test methods; `T015` depends on README content so run after `T014`)
+- Within **US2 tests**: `T019` and `T020` can run in parallel
+- Within **US3 tests**: `T023` and `T024` can run in parallel
+- Within **Phase 6**: `T028` and `T029` can run in parallel before `T030`
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch the US1 template failing tests together (different test methods, same file):
+Task T010: "VPC, subnets, EC2 SG, IAM profile, EC2 instance structure"
+Task T011: "ALB resource, target group, HTTP listener, health-check configuration"
+Task T012: "AllowedSshCidr parameter wired to security group ingress, no hardcoded CIDR"
+Task T013: "EC2 replacement safety — DynamoDB and ALB independent of EC2 lifecycle"
+
+# Launch documentation tests in parallel:
+Task T014: "Launch prerequisites and runtime environment variables"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+# Launch the US2 failing tests together:
+Task T019: "HTTPS listener, HTTP redirect, Route 53 alias, payslip.co.za tags — AwsCloudFormationTemplateTests.cs"
+Task T020: "ACM prerequisites, DNS ownership, cost disclosures — AwsDeploymentDocumentationTests.cs"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+# Launch the US3 failing tests together:
+Task T023: "PITR enablement and restore-to-new-table safety — DynamoDbBackupProtectionTests.cs"
+Task T024: "Backup IAM permissions, backup-mode output, restore runbook content — AwsCloudFormationTemplateTests.cs + AwsDeploymentDocumentationTests.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL — blocks all stories)
+3. Complete Phase 3: User Story 1
+   - Delivers EC2 + ALB (no public domain) + DynamoDB working environment
+   - Five-action launch workflow documented and test-verified
+   - ALB, allowlist, replacement safety, and signal inventory all test-covered
+4. Present Manual Test Gate prompt — await engineer `approve` before any git operation
+5. **STOP and VALIDATE**: confirm operators can launch the working environment independently of public DNS
+
+### Incremental Delivery
+
+1. Finish Setup + Foundational → deployment contract, runtime expectations, and signal inventory locked
+2. Deliver **US1** → core launchable AWS environment with ALB and DynamoDB, five-step workflow verified
+3. Deliver **US2** → public `payslip.co.za` entry point, HTTPS, Route 53, operational naming
+4. Deliver **US3** → automated DynamoDB PITR protection and documented restore drill
+5. Finish with **Polish** to align docs and run full validation suite
+
+### Parallel Team Strategy
+
+1. One developer handles Phase 1 Setup and Phase 2 Foundational together
+2. After Foundational checkpoint:
+   - Developer A: US1 — compute, ALB, bootstrap, allowlist, replacement safety, five-step docs
+   - Developer B: US2 — public domain routing and DNS/TLS docs (branches off after US1 YAML is stable)
+   - Developer C: US3 — DynamoDB backup protection hosted service and restore docs
+3. Merge changes to `infra/aws/cloudformation/payslip4all-web.yaml` and `infra/aws/cloudformation/README.md` carefully — these files are shared across US1, US2, and US3
+
+---
+
+## Notes
+
+- `[P]` tasks can run in parallel because they target separate files or non-overlapping test methods
+- All user-story tasks carry story labels and exact file paths for traceability
+- Each story is independently testable from the operator's perspective before subsequent stories begin
+- FR-002 is fully satisfied at US2 completion (public load-balanced entry on `payslip.co.za`); US1 satisfies the load-balancer infrastructure prerequisite without requiring public DNS
+- FR-006, FR-009, FR-011, and SC-005 each have dedicated test tasks (T012, T005, T013, T015) to ensure they are verified before implementation is marked complete
+- The CloudFormation template and deployment README are shared assets across stories; parallel work must focus on isolated test methods and separate code files first to avoid merge conflicts
+- Do not auto-commit; the Manual Test Gate must be presented and approved before any `git commit`, `git merge`, or `git push`

--- a/src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbBackupProtectionHostedService.cs
+++ b/src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbBackupProtectionHostedService.cs
@@ -1,0 +1,104 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Payslip4All.Infrastructure.Persistence.DynamoDB;
+
+public sealed class DynamoDbBackupProtectionHostedService : IHostedService
+{
+    private readonly IAmazonDynamoDB _dynamoDb;
+    private readonly ILogger<DynamoDbBackupProtectionHostedService> _logger;
+    private readonly string _prefix;
+    private readonly string? _endpoint;
+    private readonly bool _enablePointInTimeRecovery;
+
+    public DynamoDbBackupProtectionHostedService(
+        IAmazonDynamoDB dynamoDb,
+        ILogger<DynamoDbBackupProtectionHostedService> logger)
+    {
+        _dynamoDb = dynamoDb;
+        _logger = logger;
+        _prefix = DynamoDbTableProvisioner.GetCurrentTablePrefix();
+        _endpoint = Environment.GetEnvironmentVariable("DYNAMODB_ENDPOINT")?.Trim();
+        _enablePointInTimeRecovery = !string.Equals(
+            Environment.GetEnvironmentVariable("DYNAMODB_ENABLE_PITR")?.Trim(),
+            "false",
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!_enablePointInTimeRecovery)
+        {
+            _logger.LogInformation("DynamoDB point-in-time recovery protection is disabled by configuration.");
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(_endpoint))
+        {
+            _logger.LogInformation(
+                "Skipping DynamoDB point-in-time recovery protection because DYNAMODB_ENDPOINT is configured for a local or custom endpoint.");
+            return;
+        }
+
+        foreach (var tableName in DynamoDbTableProvisioner.GetRequiredTableNames(_prefix))
+        {
+            DescribeContinuousBackupsResponse describeResponse;
+            try
+            {
+                describeResponse = await _dynamoDb.DescribeContinuousBackupsAsync(
+                    new DescribeContinuousBackupsRequest
+                    {
+                        TableName = tableName
+                    },
+                    cancellationToken);
+            }
+            catch (ResourceNotFoundException)
+            {
+                _logger.LogWarning(
+                    "Skipping point-in-time recovery enablement because DynamoDB table '{TableName}' does not exist yet.",
+                    tableName);
+                continue;
+            }
+
+            var currentStatus = describeResponse
+                .ContinuousBackupsDescription?
+                .PointInTimeRecoveryDescription?
+                .PointInTimeRecoveryStatus;
+
+            if (currentStatus == PointInTimeRecoveryStatus.ENABLED)
+            {
+                _logger.LogInformation(
+                    "DynamoDB point-in-time recovery is already enabled for table '{TableName}'.",
+                    tableName);
+                continue;
+            }
+
+            await _dynamoDb.UpdateContinuousBackupsAsync(
+                new UpdateContinuousBackupsRequest
+                {
+                    TableName = tableName,
+                    PointInTimeRecoverySpecification = new PointInTimeRecoverySpecification
+                    {
+                        PointInTimeRecoveryEnabled = true
+                    }
+                },
+                cancellationToken);
+
+            _logger.LogInformation(
+                "Enabled DynamoDB point-in-time recovery for table '{TableName}'.",
+                tableName);
+        }
+    }
+
+    public static string BuildRestoreTargetTableName(string liveTableName, DateTimeOffset restorePointUtc)
+    {
+        if (string.IsNullOrWhiteSpace(liveTableName))
+            throw new ArgumentException("A live table name is required.", nameof(liveTableName));
+
+        return $"{liveTableName}-restore-{restorePointUtc:yyyyMMddHHmmss}";
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbServiceExtensions.cs
+++ b/src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbServiceExtensions.cs
@@ -38,7 +38,10 @@ public static class DynamoDbServiceExtensions
 
         services.AddSingleton<DynamoDbTableProvisioner>();
         services.AddSingleton<DynamoDbPaymentBootstrapHostedService>();
+        services.AddSingleton<DynamoDbBackupProtectionHostedService>();
+        services.AddHostedService(sp => sp.GetRequiredService<DynamoDbTableProvisioner>());
         services.AddHostedService(sp => sp.GetRequiredService<DynamoDbPaymentBootstrapHostedService>());
+        services.AddHostedService(sp => sp.GetRequiredService<DynamoDbBackupProtectionHostedService>());
 
         return services;
     }

--- a/src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbTableProvisioner.cs
+++ b/src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbTableProvisioner.cs
@@ -28,10 +28,35 @@ public sealed class DynamoDbTableProvisioner : IHostedService
     {
         _dynamoDb = dynamoDb;
         _logger = logger;
-        _prefix = (Environment.GetEnvironmentVariable("DYNAMODB_TABLE_PREFIX")?.Trim()
-                   ?? "payslip4all");
+        _prefix = GetCurrentTablePrefix();
         _activationTimeout = activationTimeout ?? DefaultActivationTimeout;
         _pollInterval = pollInterval ?? DefaultPollInterval;
+    }
+
+    public static string GetCurrentTablePrefix()
+    {
+        return Environment.GetEnvironmentVariable("DYNAMODB_TABLE_PREFIX")?.Trim()
+               ?? "payslip4all";
+    }
+
+    public static IReadOnlyList<string> GetRequiredTableNames(string prefix)
+    {
+        return new[]
+        {
+            $"{prefix}_users",
+            $"{prefix}_companies",
+            $"{prefix}_employees",
+            $"{prefix}_employee_loans",
+            $"{prefix}_payslips",
+            $"{prefix}_payslip_loan_deductions",
+            $"{prefix}_wallets",
+            $"{prefix}_wallet_activities",
+            $"{prefix}_payslip_pricing",
+            $"{prefix}_payment_return_evidences",
+            $"{prefix}_outcome_normalization_decisions",
+            $"{prefix}_unmatched_payment_return_records",
+            $"{prefix}_wallet_topup_attempts"
+        };
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)

--- a/src/Payslip4All.Web/Endpoints/HealthEndpoint.cs
+++ b/src/Payslip4All.Web/Endpoints/HealthEndpoint.cs
@@ -1,0 +1,16 @@
+namespace Payslip4All.Web.Endpoints;
+
+public static class HealthEndpoint
+{
+    public const string Path = "/health";
+    public const string HealthyStatus = "Healthy";
+
+    public static IResult Handle()
+    {
+        return Results.Ok(new
+        {
+            status = HealthyStatus,
+            utc = DateTimeOffset.UtcNow
+        });
+    }
+}

--- a/src/Payslip4All.Web/Program.cs
+++ b/src/Payslip4All.Web/Program.cs
@@ -205,12 +205,14 @@ if (!app.Environment.IsDevelopment())
 // Forwarded headers MUST be first so UseHttpsRedirection() sees the correct scheme
 // when the app is behind a TLS-terminating reverse proxy (nginx, Apache, Azure, etc.).
 app.UseForwardedHeaders();
+app.UseSerilogRequestLogging();
 app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseGlobalExceptionHandler();
 app.UseRouting();
 app.UseAuthentication();
 app.UseAuthorization();
+app.MapGet(HealthEndpoint.Path, HealthEndpoint.Handle);
 app.MapPost("/api/payments/payfast/notify", PayFastNotifyEndpoint.HandleAsync);
 app.MapRazorPages();
 app.MapBlazorHub();

--- a/tests/Payslip4All.Infrastructure.Tests/Persistence/DynamoDB/DynamoDbBackupProtectionTests.cs
+++ b/tests/Payslip4All.Infrastructure.Tests/Persistence/DynamoDB/DynamoDbBackupProtectionTests.cs
@@ -3,10 +3,12 @@ using Amazon.DynamoDBv2.Model;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Payslip4All.Infrastructure.Tests.DynamoDB;
 using Payslip4All.Infrastructure.Persistence.DynamoDB;
 
 namespace Payslip4All.Infrastructure.Tests.Persistence.DynamoDB;
 
+[Collection(DynamoDbTestCollection.Name)]
 public class DynamoDbBackupProtectionTests
 {
     [Fact]

--- a/tests/Payslip4All.Infrastructure.Tests/Persistence/DynamoDB/DynamoDbBackupProtectionTests.cs
+++ b/tests/Payslip4All.Infrastructure.Tests/Persistence/DynamoDB/DynamoDbBackupProtectionTests.cs
@@ -1,0 +1,165 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Payslip4All.Infrastructure.Persistence.DynamoDB;
+
+namespace Payslip4All.Infrastructure.Tests.Persistence.DynamoDB;
+
+public class DynamoDbBackupProtectionTests
+{
+    [Fact]
+    public async Task StartAsync_WhenHostedAwsConfigurationIsActive_EnablesPointInTimeRecoveryForAllRequiredTables()
+    {
+        var dynamoDb = new Mock<IAmazonDynamoDB>();
+        var prefix = $"backup_{Guid.NewGuid():N}";
+
+        dynamoDb
+            .Setup(x => x.DescribeContinuousBackupsAsync(It.IsAny<DescribeContinuousBackupsRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DescribeContinuousBackupsResponse
+            {
+                ContinuousBackupsDescription = new ContinuousBackupsDescription
+                {
+                    PointInTimeRecoveryDescription = new PointInTimeRecoveryDescription
+                    {
+                        PointInTimeRecoveryStatus = PointInTimeRecoveryStatus.DISABLED
+                    }
+                }
+            });
+
+        dynamoDb
+            .Setup(x => x.UpdateContinuousBackupsAsync(It.IsAny<UpdateContinuousBackupsRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UpdateContinuousBackupsResponse());
+
+        await WithEnvironment(prefix, null, null, async () =>
+        {
+            var sut = CreateSut(dynamoDb.Object);
+            await sut.StartAsync(CancellationToken.None);
+        });
+
+        dynamoDb.Verify(
+            x => x.UpdateContinuousBackupsAsync(
+                It.Is<UpdateContinuousBackupsRequest>(r =>
+                    r.PointInTimeRecoverySpecification.PointInTimeRecoveryEnabled
+                    && r.TableName == $"{prefix}_users"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        dynamoDb.Verify(
+            x => x.UpdateContinuousBackupsAsync(
+                It.IsAny<UpdateContinuousBackupsRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(13));
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenRunningAgainstLocalEndpoint_SkipsBackupEnablement()
+    {
+        var dynamoDb = new Mock<IAmazonDynamoDB>();
+
+        await WithEnvironment("localprefix", "http://localhost:8000", null, async () =>
+        {
+            var sut = CreateSut(dynamoDb.Object);
+            await sut.StartAsync(CancellationToken.None);
+        });
+
+        dynamoDb.Verify(
+            x => x.UpdateContinuousBackupsAsync(
+                It.IsAny<UpdateContinuousBackupsRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenPointInTimeRecoveryAlreadyEnabled_DoesNotReapplyProtection()
+    {
+        var dynamoDb = new Mock<IAmazonDynamoDB>();
+
+        dynamoDb
+            .Setup(x => x.DescribeContinuousBackupsAsync(It.IsAny<DescribeContinuousBackupsRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DescribeContinuousBackupsResponse
+            {
+                ContinuousBackupsDescription = new ContinuousBackupsDescription
+                {
+                    PointInTimeRecoveryDescription = new PointInTimeRecoveryDescription
+                    {
+                        PointInTimeRecoveryStatus = PointInTimeRecoveryStatus.ENABLED
+                    }
+                }
+            });
+
+        await WithEnvironment("enabledprefix", null, null, async () =>
+        {
+            var sut = CreateSut(dynamoDb.Object);
+            await sut.StartAsync(CancellationToken.None);
+        });
+
+        dynamoDb.Verify(
+            x => x.UpdateContinuousBackupsAsync(
+                It.IsAny<UpdateContinuousBackupsRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenPointInTimeRecoveryIsDisabledByConfiguration_SkipsProtection()
+    {
+        var dynamoDb = new Mock<IAmazonDynamoDB>();
+
+        await WithEnvironment("disabledprefix", null, "false", async () =>
+        {
+            var sut = CreateSut(dynamoDb.Object);
+            await sut.StartAsync(CancellationToken.None);
+        });
+
+        dynamoDb.Verify(
+            x => x.UpdateContinuousBackupsAsync(
+                It.IsAny<UpdateContinuousBackupsRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void BuildRestoreTargetTableName_ReturnsDistinctNonLiveTableName()
+    {
+        var restorePoint = new DateTimeOffset(2026, 04, 07, 12, 30, 45, TimeSpan.Zero);
+
+        var targetTableName = DynamoDbBackupProtectionHostedService.BuildRestoreTargetTableName(
+            "payslip4all_wallets",
+            restorePoint);
+
+        Assert.Equal("payslip4all_wallets-restore-20260407123045", targetTableName);
+        Assert.NotEqual("payslip4all_wallets", targetTableName);
+        Assert.Contains("-restore-", targetTableName, StringComparison.Ordinal);
+    }
+
+    private static IHostedService CreateSut(IAmazonDynamoDB dynamoDb)
+    {
+        return new DynamoDbBackupProtectionHostedService(
+            dynamoDb,
+            NullLogger<DynamoDbBackupProtectionHostedService>.Instance);
+    }
+
+    private static async Task WithEnvironment(string prefix, string? endpoint, string? enablePointInTimeRecovery, Func<Task> action)
+    {
+        var savedPrefix = Environment.GetEnvironmentVariable("DYNAMODB_TABLE_PREFIX");
+        var savedEndpoint = Environment.GetEnvironmentVariable("DYNAMODB_ENDPOINT");
+        var savedEnablePointInTimeRecovery = Environment.GetEnvironmentVariable("DYNAMODB_ENABLE_PITR");
+
+        Environment.SetEnvironmentVariable("DYNAMODB_TABLE_PREFIX", prefix);
+        Environment.SetEnvironmentVariable("DYNAMODB_ENDPOINT", endpoint);
+        Environment.SetEnvironmentVariable("DYNAMODB_ENABLE_PITR", enablePointInTimeRecovery);
+
+        try
+        {
+            await action();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DYNAMODB_TABLE_PREFIX", savedPrefix);
+            Environment.SetEnvironmentVariable("DYNAMODB_ENDPOINT", savedEndpoint);
+            Environment.SetEnvironmentVariable("DYNAMODB_ENABLE_PITR", savedEnablePointInTimeRecovery);
+        }
+    }
+}

--- a/tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs
+++ b/tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs
@@ -99,8 +99,8 @@ public class AwsCloudFormationTemplateTests
         Assert.Contains("CertificateArn: !Ref CertificateArn", template, StringComparison.Ordinal);
         Assert.Contains("AWS::Route53::RecordSet", template, StringComparison.Ordinal);
         Assert.Contains("EvaluateTargetHealth: true", template, StringComparison.Ordinal);
-        Assert.Contains("payslip-co-za-web-${EnvironmentName}", template, StringComparison.Ordinal);
-        Assert.Contains("payslip-co-za-alb-${EnvironmentName}", template, StringComparison.Ordinal);
+        Assert.Contains("payslip4all-co-za-web-${EnvironmentName}", template, StringComparison.Ordinal);
+        Assert.Contains("payslip4all-co-za-alb-${EnvironmentName}", template, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs
+++ b/tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs
@@ -1,0 +1,133 @@
+using System.Text.RegularExpressions;
+
+namespace Payslip4All.Web.Tests.Infrastructure;
+
+public class AwsCloudFormationTemplateTests
+{
+    [Fact]
+    public void Template_DeclaresRequiredParameters_And_DynamoDbDefaults()
+    {
+        var template = LoadTemplate();
+
+        Assert.Contains("Parameters:", template, StringComparison.Ordinal);
+        Assert.Contains("EnvironmentName:", template, StringComparison.Ordinal);
+        Assert.Contains("DomainName:", template, StringComparison.Ordinal);
+        Assert.Contains("HostedZoneId:", template, StringComparison.Ordinal);
+        Assert.Contains("CertificateArn:", template, StringComparison.Ordinal);
+        Assert.Contains("InstanceType:", template, StringComparison.Ordinal);
+        Assert.Contains("ArtifactSource:", template, StringComparison.Ordinal);
+        Assert.Contains("AllowedSshCidr:", template, StringComparison.Ordinal);
+        Assert.Contains("DynamoDbRegion:", template, StringComparison.Ordinal);
+        Assert.Contains("DynamoDbTablePrefix:", template, StringComparison.Ordinal);
+        Assert.Contains("HostedPaymentsSecretArn:", template, StringComparison.Ordinal);
+        Assert.Contains("EnablePointInTimeRecovery:", template, StringComparison.Ordinal);
+        Assert.Contains("Default: 'true'", template, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Template_ExposesCompleteOperatorSignalInventory()
+    {
+        var template = LoadTemplate();
+
+        Assert.Contains("Outputs:", template, StringComparison.Ordinal);
+        Assert.Contains("ApplicationUrl:", template, StringComparison.Ordinal);
+        Assert.Contains("InstanceId:", template, StringComparison.Ordinal);
+        Assert.Contains("LoadBalancerArn:", template, StringComparison.Ordinal);
+        Assert.Contains("InstanceSecurityGroupId:", template, StringComparison.Ordinal);
+        Assert.Contains("LoadBalancerSecurityGroupId:", template, StringComparison.Ordinal);
+        Assert.Contains("HostedPaymentsSecretReference:", template, StringComparison.Ordinal);
+        Assert.Contains("BackupProtectionMode:", template, StringComparison.Ordinal);
+        Assert.Contains("RestoreRunbook:", template, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Template_ProvisionsSingleInstanceComputeNetwork_And_IamRuntimeResources()
+    {
+        var template = LoadTemplate();
+
+        Assert.Contains("AWS::EC2::VPC", template, StringComparison.Ordinal);
+        Assert.Contains("AWS::EC2::Subnet", template, StringComparison.Ordinal);
+        Assert.Contains("AWS::EC2::InternetGateway", template, StringComparison.Ordinal);
+        Assert.Contains("AWS::EC2::RouteTable", template, StringComparison.Ordinal);
+        Assert.Contains("AWS::EC2::SecurityGroup", template, StringComparison.Ordinal);
+        Assert.Contains("AWS::EC2::Instance", template, StringComparison.Ordinal);
+        Assert.Contains("AWS::IAM::Role", template, StringComparison.Ordinal);
+        Assert.Contains("AWS::IAM::InstanceProfile", template, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Template_PlacesTheApplicationBehindAnAlb_WithHealthBasedRouting()
+    {
+        var template = LoadTemplate();
+
+        Assert.Contains("AWS::ElasticLoadBalancingV2::LoadBalancer", template, StringComparison.Ordinal);
+        Assert.Contains("AWS::ElasticLoadBalancingV2::TargetGroup", template, StringComparison.Ordinal);
+        Assert.Contains("AWS::ElasticLoadBalancingV2::Listener", template, StringComparison.Ordinal);
+        Assert.Contains("HealthCheckPath: /health", template, StringComparison.Ordinal);
+        Assert.Contains("Targets:", template, StringComparison.Ordinal);
+        Assert.Contains("Id: !Ref WebInstance", template, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Template_UsesAllowedSshCidr_WithoutHardcodedOperatorAccess()
+    {
+        var template = LoadTemplate();
+
+        Assert.Matches(@"AllowedSshCidr:\s*\n\s*Type:\s*String", template);
+        Assert.Matches(@"FromPort:\s*22\s*\n\s*ToPort:\s*22\s*\n\s*CidrIp:\s*!Ref AllowedSshCidr", template);
+        Assert.DoesNotContain("FromPort: 22\n          ToPort: 22\n          CidrIp: 0.0.0.0/0", template, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Template_KeepsSharedInfrastructure_IndependentOfEc2Replacement()
+    {
+        var template = LoadTemplate();
+
+        Assert.Contains("ApplicationLoadBalancer:", template, StringComparison.Ordinal);
+        Assert.Contains("ApplicationTargetGroup:", template, StringComparison.Ordinal);
+        Assert.Contains("PublicDnsRecord:", template, StringComparison.Ordinal);
+        Assert.Contains("PublicVpc:", template, StringComparison.Ordinal);
+        Assert.DoesNotContain("DependsOn: WebInstance", template, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Template_ImplementsHttpsPublishing_And_HealthAwareDnsRouting()
+    {
+        var template = LoadTemplate();
+
+        Assert.Contains("RedirectConfig", template, StringComparison.Ordinal);
+        Assert.Contains("CertificateArn: !Ref CertificateArn", template, StringComparison.Ordinal);
+        Assert.Contains("AWS::Route53::RecordSet", template, StringComparison.Ordinal);
+        Assert.Contains("EvaluateTargetHealth: true", template, StringComparison.Ordinal);
+        Assert.Contains("payslip-co-za-web-${EnvironmentName}", template, StringComparison.Ordinal);
+        Assert.Contains("payslip-co-za-alb-${EnvironmentName}", template, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Template_GrantsBackupPermissions_RestorePermissions_And_RecoveryOutputs()
+    {
+        var template = LoadTemplate();
+
+        Assert.Contains("dynamodb:DescribeContinuousBackups", template, StringComparison.Ordinal);
+        Assert.Contains("dynamodb:RestoreTableToPointInTime", template, StringComparison.Ordinal);
+        Assert.Contains("dynamodb:UpdateContinuousBackups", template, StringComparison.Ordinal);
+        Assert.Contains("dynamodb:ListTables", template, StringComparison.Ordinal);
+        Assert.Contains("recovery", template, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string LoadTemplate()
+    {
+        return File.ReadAllText(Path.Combine(GetSolutionRoot(), "infra", "aws", "cloudformation", "payslip4all-web.yaml"));
+    }
+
+    private static string GetSolutionRoot()
+    {
+        var currentDir = Directory.GetCurrentDirectory();
+        while (currentDir is not null && !File.Exists(Path.Combine(currentDir, "Payslip4All.sln")))
+        {
+            currentDir = Directory.GetParent(currentDir)?.FullName;
+        }
+
+        return currentDir ?? throw new InvalidOperationException("Could not find solution root.");
+    }
+}

--- a/tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs
+++ b/tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using YamlDotNet.RepresentationModel;
 
 namespace Payslip4All.Web.Tests.Infrastructure;
 
@@ -62,10 +63,10 @@ public class AwsCloudFormationTemplateTests
 
         Assert.Contains("AWS::ElasticLoadBalancingV2::LoadBalancer", template, StringComparison.Ordinal);
         Assert.Contains("AWS::ElasticLoadBalancingV2::TargetGroup", template, StringComparison.Ordinal);
+        Assert.Contains("AWS::ElasticLoadBalancingV2::TargetGroupAttachment", template, StringComparison.Ordinal);
         Assert.Contains("AWS::ElasticLoadBalancingV2::Listener", template, StringComparison.Ordinal);
         Assert.Contains("HealthCheckPath: /health", template, StringComparison.Ordinal);
-        Assert.Contains("Targets:", template, StringComparison.Ordinal);
-        Assert.Contains("Id: !Ref WebInstance", template, StringComparison.Ordinal);
+        Assert.Contains("TargetId: !Ref WebInstance", template, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -81,13 +82,13 @@ public class AwsCloudFormationTemplateTests
     [Fact]
     public void Template_KeepsSharedInfrastructure_IndependentOfEc2Replacement()
     {
-        var template = LoadTemplate();
+        var resources = LoadResources();
 
-        Assert.Contains("ApplicationLoadBalancer:", template, StringComparison.Ordinal);
-        Assert.Contains("ApplicationTargetGroup:", template, StringComparison.Ordinal);
-        Assert.Contains("PublicDnsRecord:", template, StringComparison.Ordinal);
-        Assert.Contains("PublicVpc:", template, StringComparison.Ordinal);
-        Assert.DoesNotContain("DependsOn: WebInstance", template, StringComparison.Ordinal);
+        Assert.False(ResourceReferencesNode(resources, "ApplicationLoadBalancer", "WebInstance"));
+        Assert.False(ResourceReferencesNode(resources, "ApplicationTargetGroup", "WebInstance"));
+        Assert.False(ResourceReferencesNode(resources, "PublicDnsRecord", "WebInstance"));
+        Assert.False(ResourceReferencesNode(resources, "PublicVpc", "WebInstance"));
+        Assert.True(ResourceReferencesNode(resources, "WebInstanceTargetAttachment", "WebInstance"));
     }
 
     [Fact]
@@ -97,10 +98,26 @@ public class AwsCloudFormationTemplateTests
 
         Assert.Contains("RedirectConfig", template, StringComparison.Ordinal);
         Assert.Contains("CertificateArn: !Ref CertificateArn", template, StringComparison.Ordinal);
+        Assert.Contains("SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06", template, StringComparison.Ordinal);
         Assert.Contains("AWS::Route53::RecordSet", template, StringComparison.Ordinal);
         Assert.Contains("EvaluateTargetHealth: true", template, StringComparison.Ordinal);
         Assert.Contains("payslip4all-co-za-web-${EnvironmentName}", template, StringComparison.Ordinal);
         Assert.Contains("payslip4all-co-za-alb-${EnvironmentName}", template, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Template_WaitsForBootstrapHealth_And_SecuresEnvironmentFileBeforeWritingSecrets()
+    {
+        var template = LoadTemplate();
+
+        Assert.Contains("CreationPolicy:", template, StringComparison.Ordinal);
+        Assert.Contains("ResourceSignal:", template, StringComparison.Ordinal);
+        Assert.Contains("Timeout: PT15M", template, StringComparison.Ordinal);
+        Assert.Contains("install -m 0600 /dev/null \"${ENV_FILE}\"", template, StringComparison.Ordinal);
+        Assert.Contains("chmod 600 \"${ENV_FILE}\"", template, StringComparison.Ordinal);
+        Assert.Contains("aws cloudformation signal-resource", template, StringComparison.Ordinal);
+        Assert.Contains("systemctl is-active --quiet payslip4all.service", template, StringComparison.Ordinal);
+        Assert.Contains("http://127.0.0.1/health", template, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -118,6 +135,55 @@ public class AwsCloudFormationTemplateTests
     private static string LoadTemplate()
     {
         return File.ReadAllText(Path.Combine(GetSolutionRoot(), "infra", "aws", "cloudformation", "payslip4all-web.yaml"));
+    }
+
+    private static YamlMappingNode LoadResources()
+    {
+        using var reader = new StringReader(LoadTemplate());
+        var stream = new YamlStream();
+        stream.Load(reader);
+
+        var root = (YamlMappingNode)stream.Documents[0].RootNode;
+        return (YamlMappingNode)root.Children[new YamlScalarNode("Resources")];
+    }
+
+    private static bool ResourceReferencesNode(YamlMappingNode resources, string resourceName, string targetName)
+    {
+        var resource = (YamlMappingNode)resources.Children[new YamlScalarNode(resourceName)];
+        return NodeContainsReference(resource, targetName);
+    }
+
+    private static bool NodeContainsReference(YamlNode node, string targetName)
+    {
+        switch (node)
+        {
+            case YamlScalarNode scalar:
+                return string.Equals(scalar.Value, targetName, StringComparison.Ordinal);
+
+            case YamlSequenceNode sequence:
+                return sequence.Children.Any(child => NodeContainsReference(child, targetName));
+
+            case YamlMappingNode mapping:
+                foreach (var (key, value) in mapping.Children)
+                {
+                    if (key is YamlScalarNode scalarKey
+                        && string.Equals(scalarKey.Value, "DependsOn", StringComparison.Ordinal)
+                        && NodeContainsReference(value, targetName))
+                    {
+                        return true;
+                    }
+
+                    if (NodeContainsReference(value, targetName))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+
+            default:
+                return false;
+        }
     }
 
     private static string GetSolutionRoot()

--- a/tests/Payslip4All.Web.Tests/Infrastructure/AwsDeploymentDocumentationTests.cs
+++ b/tests/Payslip4All.Web.Tests/Infrastructure/AwsDeploymentDocumentationTests.cs
@@ -54,7 +54,7 @@ public class AwsDeploymentDocumentationTests
     {
         var readme = LoadDeploymentReadme();
 
-        Assert.Contains("payslip.co.za", readme, StringComparison.Ordinal);
+        Assert.Contains("payslip4all.co.za", readme, StringComparison.Ordinal);
         Assert.Contains("Application Load Balancer", readme, StringComparison.Ordinal);
         Assert.Contains("Route 53", readme, StringComparison.Ordinal);
         Assert.Contains("ACM", readme, StringComparison.Ordinal);

--- a/tests/Payslip4All.Web.Tests/Infrastructure/AwsDeploymentDocumentationTests.cs
+++ b/tests/Payslip4All.Web.Tests/Infrastructure/AwsDeploymentDocumentationTests.cs
@@ -1,0 +1,133 @@
+using System.Text.RegularExpressions;
+
+namespace Payslip4All.Web.Tests.Infrastructure;
+
+public class AwsDeploymentDocumentationTests
+{
+    [Fact]
+    public void DeploymentGuide_ListsLaunchPrerequisites_And_RuntimeEnvironmentVariables()
+    {
+        var readme = LoadDeploymentReadme();
+
+        Assert.Contains("ArtifactSource", readme, StringComparison.Ordinal);
+        Assert.Contains("PERSISTENCE_PROVIDER=dynamodb", readme, StringComparison.Ordinal);
+        Assert.Contains("DYNAMODB_REGION", readme, StringComparison.Ordinal);
+        Assert.Contains("DYNAMODB_TABLE_PREFIX", readme, StringComparison.Ordinal);
+        Assert.Contains("AllowedSshCidr", readme, StringComparison.Ordinal);
+        Assert.Contains("HostedPaymentsSecretArn", readme, StringComparison.Ordinal);
+        Assert.Contains("HostedZoneId", readme, StringComparison.Ordinal);
+        Assert.Contains("CertificateArn", readme, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeploymentGuide_EnumeratesExactlyFiveManualPreLaunchActions()
+    {
+        var readme = LoadDeploymentReadme();
+        var actions = ExtractOrderedListItems(readme, "## Five manual pre-launch actions");
+
+        Assert.Equal(5, actions.Count);
+        Assert.Contains(actions, action => action.Contains("Publish or upload the application artifact", StringComparison.Ordinal));
+        Assert.Contains(actions, action => action.Contains("ACM certificate", StringComparison.Ordinal));
+        Assert.Contains(actions, action => action.Contains("Route 53 hosted zone", StringComparison.Ordinal));
+        Assert.Contains(actions, action => action.Contains("external secret references", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(actions, action => action.Contains("Launch `infra/aws/cloudformation/payslip4all-web.yaml`", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void DeploymentGuide_DocumentsOperatorVisibleSignals_AndBehindAlbHealthChecks()
+    {
+        var readme = LoadDeploymentReadme();
+
+        Assert.Contains("ApplicationUrl", readme, StringComparison.Ordinal);
+        Assert.Contains("InstanceId", readme, StringComparison.Ordinal);
+        Assert.Contains("LoadBalancerArn", readme, StringComparison.Ordinal);
+        Assert.Contains("InstanceSecurityGroupId", readme, StringComparison.Ordinal);
+        Assert.Contains("LoadBalancerSecurityGroupId", readme, StringComparison.Ordinal);
+        Assert.Contains("BackupProtectionMode", readme, StringComparison.Ordinal);
+        Assert.Contains("ALB target health", readme, StringComparison.Ordinal);
+        Assert.Contains("/health", readme, StringComparison.Ordinal);
+        Assert.Contains("forwarded headers", readme, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DeploymentGuide_DocumentsDnsTls_CostTradeoffs_And_ReplaceableCompute()
+    {
+        var readme = LoadDeploymentReadme();
+
+        Assert.Contains("payslip.co.za", readme, StringComparison.Ordinal);
+        Assert.Contains("Application Load Balancer", readme, StringComparison.Ordinal);
+        Assert.Contains("Route 53", readme, StringComparison.Ordinal);
+        Assert.Contains("ACM", readme, StringComparison.Ordinal);
+        Assert.Contains("free tier", readme, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("ALB", readme, StringComparison.Ordinal);
+        Assert.Contains("replacing or recreating the EC2 instance", readme, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("public entry point remains the same", readme, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DeploymentGuide_DocumentsBackupRestoreRunbook_And_NonLiveTargetRestore()
+    {
+        var readme = LoadDeploymentReadme();
+
+        Assert.Contains("point-in-time recovery", readme, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("restore", readme, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("restore to a new table", readme, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("60-minute", readme, StringComparison.Ordinal);
+        Assert.Contains("/health", readme, StringComparison.Ordinal);
+        Assert.Contains("infra/aws/cloudformation/payslip4all-web.yaml", readme, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RootReadme_ReferencesCloudFormationDeploymentGuide()
+    {
+        var rootReadme = File.ReadAllText(Path.Combine(GetSolutionRoot(), "README.md"));
+
+        Assert.Contains("AWS CloudFormation Deployment", rootReadme, StringComparison.Ordinal);
+        Assert.Contains("infra/aws/cloudformation/README.md", rootReadme, StringComparison.Ordinal);
+    }
+
+    private static string LoadDeploymentReadme()
+    {
+        return File.ReadAllText(Path.Combine(GetSolutionRoot(), "infra", "aws", "cloudformation", "README.md"));
+    }
+
+    private static IReadOnlyList<string> ExtractOrderedListItems(string markdown, string heading)
+    {
+        var items = new List<string>();
+        var inSection = false;
+
+        foreach (var rawLine in markdown.Split('\n'))
+        {
+            var line = rawLine.TrimEnd('\r');
+
+            if (string.Equals(line.Trim(), heading, StringComparison.Ordinal))
+            {
+                inSection = true;
+                continue;
+            }
+
+            if (inSection && line.StartsWith("## ", StringComparison.Ordinal))
+                break;
+
+            if (!inSection)
+                continue;
+
+            var match = Regex.Match(line.Trim(), @"^\d+\.\s+(.*)$");
+            if (match.Success)
+                items.Add(match.Groups[1].Value);
+        }
+
+        return items;
+    }
+
+    private static string GetSolutionRoot()
+    {
+        var currentDir = Directory.GetCurrentDirectory();
+        while (currentDir is not null && !File.Exists(Path.Combine(currentDir, "Payslip4All.sln")))
+        {
+            currentDir = Directory.GetParent(currentDir)?.FullName;
+        }
+
+        return currentDir ?? throw new InvalidOperationException("Could not find solution root.");
+    }
+}

--- a/tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj
+++ b/tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>

--- a/tests/Payslip4All.Web.Tests/Startup/AwsDeploymentStartupTests.cs
+++ b/tests/Payslip4All.Web.Tests/Startup/AwsDeploymentStartupTests.cs
@@ -7,6 +7,7 @@ using Payslip4All.Infrastructure.Persistence.DynamoDB;
 
 namespace Payslip4All.Web.Tests.Startup;
 
+[Collection(DynamoDbStartupTestCollection.Name)]
 public sealed class AwsDeploymentStartupTests : IDisposable
 {
     private readonly Dictionary<string, string?> _savedEnv = new();

--- a/tests/Payslip4All.Web.Tests/Startup/AwsDeploymentStartupTests.cs
+++ b/tests/Payslip4All.Web.Tests/Startup/AwsDeploymentStartupTests.cs
@@ -1,0 +1,88 @@
+using Amazon.DynamoDBv2;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Payslip4All.Infrastructure.Persistence.DynamoDB;
+
+namespace Payslip4All.Web.Tests.Startup;
+
+public sealed class AwsDeploymentStartupTests : IDisposable
+{
+    private readonly Dictionary<string, string?> _savedEnv = new();
+
+    [Fact]
+    public async Task HealthEndpoint_IsPubliclyExposed_AndReturnsHealthyPayload()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/health");
+        var body = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("\"status\":\"Healthy\"", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DynamoDbProvider_WhenHostedAwsConfigured_RegistersBackupProtectionHostedService_AndTableProvisioner()
+    {
+        SetEnv("DYNAMODB_REGION", "af-south-1");
+        SetEnv("DYNAMODB_TABLE_PREFIX", "payslip4all");
+        SetEnv("DYNAMODB_ENDPOINT", null);
+        SetEnv("AWS_ACCESS_KEY_ID", null);
+        SetEnv("AWS_SECRET_ACCESS_KEY", null);
+
+        using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Development");
+            builder.UseSetting("PERSISTENCE_PROVIDER", "dynamodb");
+            builder.ConfigureServices(services =>
+            {
+                foreach (var descriptor in services.Where(d => d.ServiceType == typeof(IHostedService)).ToList())
+                    services.Remove(descriptor);
+            });
+        });
+
+        using var scope = factory.Services.CreateScope();
+
+        Assert.NotNull(scope.ServiceProvider.GetRequiredService<IAmazonDynamoDB>());
+        Assert.NotNull(scope.ServiceProvider.GetRequiredService<DynamoDbBackupProtectionHostedService>());
+        Assert.NotNull(scope.ServiceProvider.GetRequiredService<DynamoDbTableProvisioner>());
+    }
+
+    [Fact]
+    public void DynamoDbProvider_WhenRegionIsMissing_FailsFastDuringStartup()
+    {
+        SetEnv("DYNAMODB_REGION", null);
+        SetEnv("DYNAMODB_TABLE_PREFIX", "payslip4all");
+        SetEnv("DYNAMODB_ENDPOINT", null);
+        SetEnv("AWS_ACCESS_KEY_ID", null);
+        SetEnv("AWS_SECRET_ACCESS_KEY", null);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Development");
+                builder.UseSetting("PERSISTENCE_PROVIDER", "dynamodb");
+            });
+
+            using var client = factory.CreateClient();
+        });
+
+        Assert.Contains("DYNAMODB_REGION", exception.Message, StringComparison.Ordinal);
+    }
+
+    private void SetEnv(string key, string? value)
+    {
+        _savedEnv.TryAdd(key, Environment.GetEnvironmentVariable(key));
+        Environment.SetEnvironmentVariable(key, value);
+    }
+
+    public void Dispose()
+    {
+        foreach (var (key, value) in _savedEnv)
+            Environment.SetEnvironmentVariable(key, value);
+    }
+}


### PR DESCRIPTION

 ## Summary
 
 Add AWS CloudFormation deployment assets for Payslip4All using a single EC2 instance behind an ALB with DynamoDB persistence and documented recovery 
support.
 
 ## What changed
 
 - add `infra/aws/cloudformation/` with:
   - `payslip4all-web.yaml`
   - `user-data/bootstrap-payslip4all.sh`
   - deployment README
 - add feature 011 spec artifacts under `specs/011-aws-cloudformation/`
 - add `/health` endpoint for load balancer health checks
 - register and implement DynamoDB backup protection at startup
 - expose operator-visible deployment signals in the template/docs
 - document the five-step operator workflow, cost caveats, and restore process
 - add focused tests for:
   - CloudFormation template expectations
   - deployment documentation
   - startup health endpoint wiring
   - DynamoDB backup protection behavior
 
 ## Notable implementation details
 
 - EC2 runs the web app with `PERSISTENCE_PROVIDER=dynamodb`
 - ALB handles routing and health checks
 - `payslip4all.co.za` is the intended public entry point
 - DynamoDB PITR is enabled for hosted AWS environments
 - restore flow is documented to restore into a non-live target table
 - access is parameterized, including operator SSH CIDR and optional secret reference
 
 ## Validation
 
 - `dotnet test tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj --filter "FullyQualifiedName~Aws"`
 - `dotnet test tests/Payslip4All.Infrastructure.Tests/Payslip4All.Infrastructure.Tests.csproj --filter 
"FullyQualifiedName~DynamoDbBackupProtectionTests"`
 - `dotnet test tests/Payslip4All.Infrastructure.Tests/Payslip4All.Infrastructure.Tests.csproj --filter "Category!=Integration"`
 
 ## Notes
 
 - `.github/agents/copilot-instructions.md` was intentionally not included
 - PR creation via `gh` was blocked locally by missing GitHub CLI authentication


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AWS CloudFormation deployment path for a single-EC2 web host fronted by an internet-facing ALB with Route 53 publishing
  * Public /health endpoint for readiness/ALB checks
  * Automated DynamoDB point-in-time recovery (PITR) enablement with deterministic restore naming

* **Chores**
  * EC2 bootstrap automation for artifact deployment and environment wiring
  * DynamoDB provisioning/startup enhancements to support backup/restore

* **Documentation**
  * Deployment guide, quickstart, contract, plan, runbooks, and operator checklists

* **Tests**
  * Validation suite for template, docs, startup behavior, and backup protection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->