### PR TITLE
Simplify AWS web stack

### DIFF
--- a/infra/aws/cloudformation/README.md
+++ b/infra/aws/cloudformation/README.md
@@ -1,13 +1,13 @@
 # AWS CloudFormation Deployment
 
-This guide describes the repository-owned AWS deployment path for Payslip4All using a single EC2 instance, an Application Load Balancer, Route 53, and DynamoDB.
+This guide describes the repository-owned AWS deployment path for Payslip4All using a single EC2 instance, an Elastic IP, SSM Session Manager access, and DynamoDB.
 
 ## What this deployment creates
 
-- One internet-facing Application Load Balancer for `payslip4all.co.za`
-- One EC2 web host tagged with payslip4all.co.za-derived metadata
-- An optional Route 53 alias record that points `payslip4all.co.za` to the ALB when a hosted zone ID is provided
-- One IAM instance profile so the app can use the AWS SDK credential chain
+- One EC2 web host for Payslip4All
+- One Elastic IP attached directly to the EC2 instance
+- One security group that exposes HTTP on port 80
+- One IAM instance profile so the app can use the AWS SDK credential chain and SSM Session Manager
 - A DynamoDB-backed runtime with `PERSISTENCE_PROVIDER=dynamodb`
 - Automated DynamoDB point-in-time recovery for regular backups in hosted AWS
 
@@ -20,13 +20,10 @@ You must prepare these values before launching the stack:
 | Parameter | Why it is required |
 |-----------|--------------------|
 | `EnvironmentName` | Distinguishes production from any future non-production environment |
-| `DomainName` | Public hostname, expected to be `payslip4all.co.za` |
-| `HostedZoneId` | Optional. When provided, Route 53 publishes the ALB alias record |
-| `CertificateArn` | Enables HTTPS on the public listener through ACM |
+| `VpcId` | Places the EC2 instance in an existing VPC |
+| `SubnetId` | Places the EC2 instance in an existing public subnet with internet access |
 | `InstanceType` | Defaults to a low-cost option such as `t3.micro`, but can be overridden |
 | `ArtifactSource` | Points the bootstrap process at the published Payslip4All bundle |
-| `AllowedSshCidr` | Restricts operator shell access to approved IP ranges |
-| `DynamoDbRegion` | Required by the application's DynamoDB startup validation |
 | `DynamoDbTablePrefix` | Namespaces the application-owned table set |
 | `HostedPaymentsSecretArn` | Optional secret reference for hosted-payment and app-specific configuration |
 
@@ -35,77 +32,73 @@ You must prepare these values before launching the stack:
 The EC2 bootstrap process writes these values into the service environment:
 
 - `PERSISTENCE_PROVIDER=dynamodb`
-- `DYNAMODB_REGION`
+- `DYNAMODB_REGION` set from the stack region
 - `DYNAMODB_TABLE_PREFIX`
-- `DYNAMODB_ENABLE_PITR`
+- `DYNAMODB_ENABLE_PITR=true`
 - `ASPNETCORE_URLS=http://0.0.0.0:80`
 
 If `HostedPaymentsSecretArn` is provided, the instance also appends the secret values to the app environment file using AWS Secrets Manager. Keep reusable secrets out of the template itself.
 
 ## Architecture and traffic flow
 
-1. If `HostedZoneId` is provided, Route 53 publishes `payslip4all.co.za` as an alias to the Application Load Balancer.
-2. The ALB terminates TLS with ACM and redirects HTTP traffic to HTTPS.
-3. The ALB forwards only healthy requests to the EC2 instance on port 80.
-4. Payslip4All responds to the ALB health check at `/health`.
-5. The web app starts with `PERSISTENCE_PROVIDER=dynamodb`, then provisions and uses the application-owned DynamoDB tables.
+1. An Elastic IP is attached directly to the EC2 instance.
+2. Public HTTP traffic reaches the app on port 80.
+3. Operators connect to the instance through SSM Session Manager instead of SSH.
+4. The web app starts with `PERSISTENCE_PROVIDER=dynamodb`, then provisions and uses the application-owned DynamoDB tables.
 
-The EC2 instance uses a payslip4all.co.za-derived `Name` tag such as `payslip4all-co-za-web-prod`. The public domain belongs to the ALB only; the instance is identified operationally through tags and instance IDs rather than a second public DNS record.
+The EC2 instance uses a `Name` tag such as `payslip4all-web-prod`. This template intentionally avoids Route 53, ACM, and Application Load Balancer resources so stack creation stays as small and direct as possible.
 
 ## Operator-visible signals
 
 Operators should verify the deployment with this explicit signal set:
 
-- CloudFormation outputs: `ApplicationUrl`, `InstanceId`, `LoadBalancerArn`, `InstanceSecurityGroupId`, `LoadBalancerSecurityGroupId`, `HostedPaymentsSecretReference`, `BackupProtectionMode`, and `RestoreRunbook`
-- ALB target health for the registered EC2 instance
-- The public `/health` endpoint
-- The payslip4all.co.za-derived `Name` tags on the ALB and EC2 instance
+- CloudFormation outputs: `ApplicationUrl`, `ElasticIpAddress`, `InstanceId`, `InstanceSecurityGroupId`, `SsmStartSessionCommand`, `HostedPaymentsSecretReference`, `BackupProtectionMode`, and `RestoreRunbook`
+- The public `/health` endpoint through the Elastic IP
+- The `Name` tag on the EC2 instance
+- SSM Session Manager access to the instance
 
-These signals are intentionally minimal: enough to verify stack identity, app reachability, network wiring, and backup posture without turning this feature into a separate observability project.
+These signals are intentionally minimal: enough to verify stack identity, app reachability, operator access, and backup posture without turning this feature into a separate platform project.
 
-## Five manual pre-launch actions
+## Manual pre-launch actions
 
 1. Publish or upload the application artifact that `ArtifactSource` will reference.
-2. Confirm the ACM certificate for `payslip4all.co.za` is issued in the target AWS region.
-3. If you want the stack to manage DNS, confirm the Route 53 hosted zone is authoritative for `payslip4all.co.za`.
-4. Gather the external secret references required for hosted-payment and application runtime configuration.
-5. Launch `infra/aws/cloudformation/payslip4all-web.yaml` with the required parameters.
+2. Confirm the chosen subnet is public and has outbound internet access.
+3. Gather the external secret references required for hosted-payment and application runtime configuration.
+4. Launch `infra/aws/cloudformation/payslip4all-web.yaml` with the required parameters.
 
-These five actions are the complete manual pre-launch workflow for this feature.
+These actions are the complete manual pre-launch workflow for this feature.
 
 ## Post-launch verification
 
 1. Wait for the stack to complete.
-2. Open `https://payslip4all.co.za`.
-3. Confirm the ALB returns the app and the EC2 instance is tagged for the same environment.
-4. Inspect ALB target health and confirm the registered instance is healthy.
-5. Call `/health` and confirm the application returns a healthy response.
+2. Open the `ApplicationUrl` output.
+3. Confirm the instance responds on `/health`.
+4. Start an SSM session using the `SsmStartSessionCommand` output.
+5. Confirm the app starts with `PERSISTENCE_PROVIDER=dynamodb`, `DYNAMODB_REGION`, and `DYNAMODB_TABLE_PREFIX`.
 
-## Free-tier and cost notes
+## Cost notes
 
-This deployment is optimized for low cost, but it is **not fully free tier** because the required edge services are billable.
+This deployment is optimized for lower cost than the previous ALB-based version.
 
 - The template defaults to a small EC2 instance type to use as much of the free tier as practical.
 - DynamoDB uses the app's on-demand table model, which is cost-efficient for low traffic.
-- **Application Load Balancer (ALB)** is a recurring cost outside the free tier.
-- **Route 53** hosted zones and DNS queries are also outside the free tier.
-- ACM certificates are not the primary cost concern here; the paid pieces are the ALB, Route 53, and any DynamoDB traffic or backup storage above the free tier.
+- The template no longer creates an Application Load Balancer or Route 53 record.
+- The main recurring costs are the EC2 instance, Elastic IP while attached, any EBS storage, and any DynamoDB traffic or backup storage above the free tier.
 
 ## Health checks and startup validation
 
-- The ALB target group probes `/health`.
-- The app trusts forwarded headers and redirects to HTTPS correctly when fronted by the ALB.
-- The web app enables request logging so behind-ALB traffic is visible in structured application logs.
-- Startup fails fast if `DYNAMODB_REGION` is missing or if only one of `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` is supplied.
+- Stack creation completes once AWS creates the instance resources; application bootstrap continues on the instance after launch.
+- The web app enables request logging so direct instance traffic is visible in structured application logs.
+- Startup fails fast if the DynamoDB configuration is incomplete at runtime.
 - The preferred hosted AWS path uses the IAM instance profile, not static AWS credentials.
 
 ## Replaceable compute behaviour
 
-The CloudFormation stack keeps networking, DNS, ALB resources, and DynamoDB-backed application data independent of the EC2 instance lifecycle. Updating the stack and replacing or recreating the EC2 instance should therefore keep application data available and ensure the public entry point remains the same, assuming the replacement instance boots successfully and rejoins the target group.
+The CloudFormation stack keeps application data in DynamoDB and keeps the public endpoint stable through the Elastic IP. Updating the stack and replacing or recreating the EC2 instance should therefore keep application data available and restore the same public endpoint once the replacement instance boots successfully and the Elastic IP is attached.
 
 ## DynamoDB backup and restore
 
-The hosted AWS deployment enables **point-in-time recovery** by default so the Payslip4All table set is regularly backed up without daily manual jobs.
+The hosted AWS deployment enables **point-in-time recovery** so the Payslip4All table set is regularly backed up without daily manual jobs.
 
 - `DYNAMODB_ENABLE_PITR=true` keeps backup protection on in hosted AWS.
 - If `DYNAMODB_ENDPOINT` is set for a local emulator, the backup-protection hosted service skips PITR configuration.
@@ -119,17 +112,15 @@ The hosted AWS deployment enables **point-in-time recovery** by default so the P
 2. Restore each required table to a new table name from the desired recovery point so every restore goes to a new table rather than the live one.
 3. Validate the restored data before any cutover.
 4. If a cutover is required, update the application's table prefix or restore mapping in a controlled maintenance window.
-5. Re-run application verification and confirm `https://payslip4all.co.za` still serves correctly after the data recovery workflow.
-
-Aim to complete the restore drill, including validation, within the feature's 60-minute recovery target.
+5. Re-run application verification and confirm the `ApplicationUrl` output still serves correctly after the data recovery workflow.
 
 ## Recommended verification
 
 After launch:
 
-1. Browse to `https://payslip4all.co.za`.
-2. Confirm HTTP requests are redirected to HTTPS.
-3. Confirm `/health` returns a healthy response through the stack.
-4. Confirm the EC2 instance is tagged with a payslip4all.co.za-derived name.
+1. Browse to the `ApplicationUrl` output.
+2. Confirm `/health` returns a healthy response through the Elastic IP.
+3. Confirm the EC2 instance is tagged with a payslip4all-derived name.
+4. Confirm SSM Session Manager can open a shell on the instance.
 5. Confirm the app starts with `PERSISTENCE_PROVIDER=dynamodb`, `DYNAMODB_REGION`, and `DYNAMODB_TABLE_PREFIX`.
 6. Confirm the hosted AWS environment reports point-in-time recovery enabled for the Payslip4All tables.

--- a/infra/aws/cloudformation/payslip4all-web.yaml
+++ b/infra/aws/cloudformation/payslip4all-web.yaml
@@ -1,22 +1,17 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: Deploy Payslip4All to AWS on a single EC2 instance behind an ALB with DynamoDB persistence.
+Description: Deploy Payslip4All to AWS on a single EC2 instance with an Elastic IP and DynamoDB persistence.
 
 Parameters:
   EnvironmentName:
     Type: String
     Default: prod
     Description: Environment identifier used in resource names and tags.
-  DomainName:
-    Type: String
-    Default: payslip4all.co.za
-    Description: Public application hostname.
-  HostedZoneId:
-    Type: String
-    Default: ''
-    Description: Optional Route 53 hosted zone ID that serves the public hostname.
-  CertificateArn:
-    Type: String
-    Description: ACM certificate ARN for the public hostname.
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: Existing VPC that hosts the Payslip4All web instance.
+  SubnetId:
+    Type: AWS::EC2::Subnet::Id
+    Description: Existing public subnet with internet access for the Payslip4All web instance.
   InstanceType:
     Type: String
     Default: t3.micro
@@ -24,13 +19,6 @@ Parameters:
   ArtifactSource:
     Type: String
     Description: HTTPS or S3-backed artifact URL for the published Payslip4All deployment bundle.
-  AllowedSshCidr:
-    Type: String
-    Default: 0.0.0.0/32
-    Description: Operator CIDR allowed to reach the instance by SSH.
-  DynamoDbRegion:
-    Type: String
-    Description: Runtime AWS region used by the DynamoDB provider.
   DynamoDbTablePrefix:
     Type: String
     Default: payslip4all
@@ -39,129 +27,24 @@ Parameters:
     Type: String
     Default: ''
     Description: Optional Secrets Manager ARN that stores hosted-payment and app secrets.
-  EnablePointInTimeRecovery:
-    Type: String
-    AllowedValues:
-      - 'true'
-      - 'false'
-    Default: 'true'
-    Description: Leave true in hosted AWS to enable regular DynamoDB backups through PITR.
 
 Resources:
-  PublicVpc:
-    Type: AWS::EC2::VPC
-    Properties:
-      CidrBlock: 10.42.0.0/16
-      EnableDnsSupport: true
-      EnableDnsHostnames: true
-      Tags:
-        - Key: Name
-          Value: !Sub payslip4all-co-za-vpc-${EnvironmentName}
-
-  InternetGateway:
-    Type: AWS::EC2::InternetGateway
-    Properties:
-      Tags:
-        - Key: Name
-          Value: !Sub payslip4all-co-za-igw-${EnvironmentName}
-
-  VpcGatewayAttachment:
-    Type: AWS::EC2::VPCGatewayAttachment
-    Properties:
-      VpcId: !Ref PublicVpc
-      InternetGatewayId: !Ref InternetGateway
-
-  PublicSubnetA:
-    Type: AWS::EC2::Subnet
-    Properties:
-      VpcId: !Ref PublicVpc
-      AvailabilityZone: !Select [0, !GetAZs '']
-      CidrBlock: 10.42.0.0/24
-      MapPublicIpOnLaunch: true
-      Tags:
-        - Key: Name
-          Value: !Sub payslip4all-co-za-public-a-${EnvironmentName}
-
-  PublicSubnetB:
-    Type: AWS::EC2::Subnet
-    Properties:
-      VpcId: !Ref PublicVpc
-      AvailabilityZone: !Select [1, !GetAZs '']
-      CidrBlock: 10.42.1.0/24
-      MapPublicIpOnLaunch: true
-      Tags:
-        - Key: Name
-          Value: !Sub payslip4all-co-za-public-b-${EnvironmentName}
-
-  PublicRouteTable:
-    Type: AWS::EC2::RouteTable
-    Properties:
-      VpcId: !Ref PublicVpc
-      Tags:
-        - Key: Name
-          Value: !Sub payslip4all-co-za-public-rt-${EnvironmentName}
-
-  DefaultRoute:
-    Type: AWS::EC2::Route
-    DependsOn: VpcGatewayAttachment
-    Properties:
-      RouteTableId: !Ref PublicRouteTable
-      DestinationCidrBlock: 0.0.0.0/0
-      GatewayId: !Ref InternetGateway
-
-  PublicSubnetARouteTableAssociation:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref PublicRouteTable
-      SubnetId: !Ref PublicSubnetA
-
-  PublicSubnetBRouteTableAssociation:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref PublicRouteTable
-      SubnetId: !Ref PublicSubnetB
-
-  LoadBalancerSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Public ingress for the Payslip4All Application Load Balancer.
-      VpcId: !Ref PublicVpc
-      SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: 80
-          ToPort: 80
-          CidrIp: 0.0.0.0/0
-        - IpProtocol: tcp
-          FromPort: 443
-          ToPort: 443
-          CidrIp: 0.0.0.0/0
-      SecurityGroupEgress:
-        - IpProtocol: -1
-          CidrIp: 0.0.0.0/0
-      Tags:
-        - Key: Name
-          Value: !Sub payslip4all-co-za-alb-sg-${EnvironmentName}
-
   InstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: EC2 ingress restricted to the ALB and operator SSH range.
-      VpcId: !Ref PublicVpc
+      GroupDescription: Public ingress for the Payslip4All EC2 host.
+      VpcId: !Ref VpcId
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
-          SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup
-        - IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          CidrIp: !Ref AllowedSshCidr
+          CidrIp: 0.0.0.0/0
       SecurityGroupEgress:
         - IpProtocol: -1
           CidrIp: 0.0.0.0/0
       Tags:
         - Key: Name
-          Value: !Sub payslip4all-co-za-web-sg-${EnvironmentName}
+          Value: !Sub payslip4all-web-sg-${EnvironmentName}
 
   AppInstanceRole:
     Type: AWS::IAM::Role
@@ -175,6 +58,8 @@ Resources:
                 - ec2.amazonaws.com
             Action:
               - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Policies:
         - PolicyName: !Sub payslip4all-web-${EnvironmentName}
           PolicyDocument:
@@ -182,7 +67,6 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - cloudformation:SignalResource
                   - dynamodb:BatchWriteItem
                   - dynamodb:CreateTable
                   - dynamodb:DeleteItem
@@ -212,7 +96,7 @@ Resources:
                 - !Ref AWS::NoValue
       Tags:
         - Key: Name
-          Value: !Sub payslip4all-co-za-web-role-${EnvironmentName}
+          Value: !Sub payslip4all-web-role-${EnvironmentName}
 
   AppInstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -220,75 +104,8 @@ Resources:
       Roles:
         - !Ref AppInstanceRole
 
-  ApplicationLoadBalancer:
-    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
-    Properties:
-      Name: !Sub payslip4all-co-za-alb-${EnvironmentName}
-      Scheme: internet-facing
-      Type: application
-      SecurityGroups:
-        - !Ref LoadBalancerSecurityGroup
-      Subnets:
-        - !Ref PublicSubnetA
-        - !Ref PublicSubnetB
-      Tags:
-        - Key: Name
-          Value: !Sub payslip4all-co-za-alb-${EnvironmentName}
-
-  ApplicationTargetGroup:
-    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    Properties:
-      Name: !Sub p4a-web-${EnvironmentName}
-      Port: 80
-      Protocol: HTTP
-      TargetType: instance
-      Targets:
-        - Id: !Ref WebInstance
-          Port: 80
-      VpcId: !Ref PublicVpc
-      HealthCheckEnabled: true
-      HealthCheckPath: /health
-      Matcher:
-        HttpCode: 200
-      Tags:
-        - Key: Name
-          Value: !Sub payslip4all-co-za-targets-${EnvironmentName}
-
-  HttpListener:
-    Type: AWS::ElasticLoadBalancingV2::Listener
-    Properties:
-      LoadBalancerArn: !Ref ApplicationLoadBalancer
-      Port: 80
-      Protocol: HTTP
-      DefaultActions:
-        - Type: redirect
-          RedirectConfig:
-            Protocol: HTTPS
-            Port: '443'
-            Host: '#{host}'
-            Path: '/#{path}'
-            Query: '#{query}'
-            StatusCode: HTTP_301
-
-  HttpsListener:
-    Type: AWS::ElasticLoadBalancingV2::Listener
-    Properties:
-      LoadBalancerArn: !Ref ApplicationLoadBalancer
-      Port: 443
-      Protocol: HTTPS
-      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
-      Certificates:
-        - CertificateArn: !Ref CertificateArn
-      DefaultActions:
-        - Type: forward
-          TargetGroupArn: !Ref ApplicationTargetGroup
-
   WebInstance:
     Type: AWS::EC2::Instance
-    CreationPolicy:
-      ResourceSignal:
-        Count: 1
-        Timeout: PT15M
     Properties:
       ImageId: '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64}}'
       InstanceType: !Ref InstanceType
@@ -298,7 +115,7 @@ Resources:
           DeviceIndex: '0'
           GroupSet:
             - !Ref InstanceSecurityGroup
-          SubnetId: !Ref PublicSubnetA
+          SubnetId: !Ref SubnetId
       MetadataOptions:
         HttpTokens: required
       UserData:
@@ -314,17 +131,6 @@ Resources:
           if ! id "$APP_USER" >/dev/null 2>&1; then
             useradd --system --home "$APP_ROOT" --shell /sbin/nologin "$APP_USER"
           fi
-          signal_failure() {
-            local reason=""
-            if (($# > 0)); then
-              reason="$1"
-            fi
-            if [[ -z "$reason" ]]; then
-              reason="bootstrap failed"
-            fi
-            aws cloudformation signal-resource --stack-name "${AWS::StackName}" --logical-resource-id WebInstance --status FAILURE --reason "$reason" --unique-id "$(hostname)" --region "${AWS::Region}" || true
-          }
-          trap 'signal_failure "bootstrap failed at line $LINENO"' ERR
           mkdir -p "$APP_ROOT" "$ENV_DIR"
           install -m 0600 /dev/null "$ENV_FILE"
           curl --fail --location --silent --show-error "${ArtifactSource}" --output /tmp/payslip4all.tgz
@@ -334,9 +140,9 @@ Resources:
           ASPNETCORE_ENVIRONMENT=Production
           ASPNETCORE_URLS=http://0.0.0.0:80
           PERSISTENCE_PROVIDER=dynamodb
-          DYNAMODB_REGION=${DynamoDbRegion}
+          DYNAMODB_REGION=${AWS::Region}
           DYNAMODB_TABLE_PREFIX=${DynamoDbTablePrefix}
-          DYNAMODB_ENABLE_PITR=${EnablePointInTimeRecovery}
+          DYNAMODB_ENABLE_PITR=true
           EOF
           chmod 600 "$ENV_FILE"
           if [[ -n "${HostedPaymentsSecretArn}" ]]; then
@@ -364,57 +170,38 @@ Resources:
           systemctl daemon-reload
           systemctl enable payslip4all.service
           systemctl restart payslip4all.service
-          for attempt in $(seq 1 12); do
-            if systemctl is-active --quiet payslip4all.service && curl --fail --silent http://127.0.0.1/health >/dev/null; then
-              aws cloudformation signal-resource --stack-name "${AWS::StackName}" --logical-resource-id WebInstance --status SUCCESS --unique-id "$(hostname)" --region "${AWS::Region}"
-              trap - ERR
-              exit 0
-            fi
-            sleep 5
-          done
-          signal_failure "payslip4all.service did not become healthy in time"
-          exit 1
       Tags:
         - Key: Name
-          Value: !Sub payslip4all-co-za-web-${EnvironmentName}
-        - Key: Domain
-          Value: !Ref DomainName
+          Value: !Sub payslip4all-web-${EnvironmentName}
 
-  PublicDnsRecord:
-    Type: AWS::Route53::RecordSet
-    Condition: HasHostedZoneId
+  ElasticIp:
+    Type: AWS::EC2::EIP
     Properties:
-      HostedZoneId: !Ref HostedZoneId
-      Name: !Ref DomainName
-      Type: A
-      AliasTarget:
-        DNSName: !GetAtt ApplicationLoadBalancer.DNSName
-        HostedZoneId: !GetAtt ApplicationLoadBalancer.CanonicalHostedZoneID
-        EvaluateTargetHealth: true
+      Domain: vpc
+      InstanceId: !Ref WebInstance
+      Tags:
+        - Key: Name
+          Value: !Sub payslip4all-web-eip-${EnvironmentName}
 
 Conditions:
-  HasHostedZoneId: !Not [!Equals [!Ref HostedZoneId, '']]
   HasHostedPaymentsSecret: !Not [!Equals [!Ref HostedPaymentsSecretArn, '']]
 
 Outputs:
   ApplicationUrl:
-    Description: Public HTTPS URL for Payslip4All.
-    Value: !If
-      - HasHostedZoneId
-      - !Sub https://${DomainName}
-      - !Sub https://${ApplicationLoadBalancer.DNSName}
+    Description: Public HTTP URL for Payslip4All.
+    Value: !Sub http://${ElasticIp}
+  ElasticIpAddress:
+    Description: Elastic IP address assigned to the EC2 instance.
+    Value: !Ref ElasticIp
   InstanceId:
     Description: The EC2 instance serving Payslip4All.
     Value: !Ref WebInstance
-  LoadBalancerArn:
-    Description: ARN of the public Application Load Balancer.
-    Value: !Ref ApplicationLoadBalancer
   InstanceSecurityGroupId:
-    Description: EC2 security group for operator troubleshooting.
+    Description: EC2 security group for network troubleshooting.
     Value: !Ref InstanceSecurityGroup
-  LoadBalancerSecurityGroupId:
-    Description: ALB security group for troubleshooting load balancer ingress.
-    Value: !Ref LoadBalancerSecurityGroup
+  SsmStartSessionCommand:
+    Description: AWS CLI command to open an SSM shell on the instance.
+    Value: !Sub aws ssm start-session --target ${WebInstance}
   HostedPaymentsSecretReference:
     Description: Secret reference used for hosted-payment and runtime app configuration updates.
     Value: !If

--- a/infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh
+++ b/infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 APP_ROOT="/opt/payslip4all"
 APP_USER="payslip4all"
 ENV_DIR="/etc/payslip4all"
-ENV_FILE="${ENV_DIR}/payslip4all.env"
+ENV_FILE="$ENV_DIR/payslip4all.env"
 SERVICE_FILE="/etc/systemd/system/payslip4all.service"
 
 ARTIFACT_SOURCE="${ARTIFACT_SOURCE:?ARTIFACT_SOURCE is required}"
@@ -15,19 +15,19 @@ DYNAMODB_TABLE_PREFIX="${DYNAMODB_TABLE_PREFIX:-payslip4all}"
 DYNAMODB_ENABLE_PITR="${DYNAMODB_ENABLE_PITR:-true}"
 HOSTED_PAYMENTS_SECRET_ARN="${HOSTED_PAYMENTS_SECRET_ARN:-}"
 
-if ! id "${APP_USER}" >/dev/null 2>&1; then
-  useradd --system --home "${APP_ROOT}" --shell /sbin/nologin "${APP_USER}"
+if ! id "$APP_USER" >/dev/null 2>&1; then
+  useradd --system --home "$APP_ROOT" --shell /sbin/nologin "$APP_USER"
 fi
 
 dnf install -y curl tar gzip jq awscli aspnetcore-runtime-8.0
 
-mkdir -p "${APP_ROOT}" "${ENV_DIR}"
-install -m 0600 /dev/null "${ENV_FILE}"
+mkdir -p "$APP_ROOT" "$ENV_DIR"
+install -m 0600 /dev/null "$ENV_FILE"
 curl --fail --location --silent --show-error "${ARTIFACT_SOURCE}" --output /tmp/payslip4all.tgz
-rm -rf "${APP_ROOT:?}/"*
-tar -xzf /tmp/payslip4all.tgz -C "${APP_ROOT}"
+find "$APP_ROOT" -mindepth 1 -exec rm -rf -- {} +
+tar -xzf /tmp/payslip4all.tgz -C "$APP_ROOT"
 
-cat > "${ENV_FILE}" <<EOF
+cat > "$ENV_FILE" <<EOF
 ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT}
 ASPNETCORE_URLS=http://0.0.0.0:80
 PERSISTENCE_PROVIDER=${PERSISTENCE_PROVIDER}
@@ -36,18 +36,18 @@ DYNAMODB_TABLE_PREFIX=${DYNAMODB_TABLE_PREFIX}
 DYNAMODB_ENABLE_PITR=${DYNAMODB_ENABLE_PITR}
 EOF
 
-chmod 600 "${ENV_FILE}"
+chmod 600 "$ENV_FILE"
 
 if [[ -n "${HOSTED_PAYMENTS_SECRET_ARN}" ]]; then
   aws secretsmanager get-secret-value \
     --secret-id "${HOSTED_PAYMENTS_SECRET_ARN}" \
     --query SecretString \
-    --output text | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "${ENV_FILE}"
+    --output text | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$ENV_FILE"
 fi
 
-chown -R "${APP_USER}:${APP_USER}" "${APP_ROOT}" "${ENV_DIR}"
+chown -R "$APP_USER:$APP_USER" "$APP_ROOT" "$ENV_DIR"
 
-cat > "${SERVICE_FILE}" <<EOF
+cat > "$SERVICE_FILE" <<EOF
 [Unit]
 Description=Payslip4All web application
 After=network-online.target
@@ -55,10 +55,10 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=${APP_USER}
-WorkingDirectory=${APP_ROOT}
-EnvironmentFile=${ENV_FILE}
-ExecStart=/usr/bin/dotnet ${APP_ROOT}/Payslip4All.Web.dll
+User=$APP_USER
+WorkingDirectory=$APP_ROOT
+EnvironmentFile=$ENV_FILE
+ExecStart=/usr/bin/dotnet $APP_ROOT/Payslip4All.Web.dll
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
## Summary

Simplify the AWS web deployment stack to a single EC2 instance with an Elastic IP.

This removes the ALB, Route 53, ACM, VPC creation, and CloudFormation startup gating so stack creation is faster and operationally simpler.

## Changes

- Reworked `infra/aws/cloudformation/payslip4all-web.yaml` to use:
  - existing `VpcId` and `SubnetId`
  - one EC2 instance
  - one security group
  - one IAM role and instance profile
  - one Elastic IP
- Added SSM Session Manager access via `AmazonSSMManagedInstanceCore`.
- Removed ALB, target groups, listeners, Route 53 record creation, ACM certificate usage, and SSH CIDR handling.
- Simplified runtime configuration by:
  - defaulting DynamoDB region to the stack region
  - always enabling PITR in hosted AWS
  - removing CloudFormation `CreationPolicy`/`SignalResource` startup gating
- Updated `infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh` to stay aligned with the template bootstrap behavior.
- Updated `infra/aws/cloudformation/README.md` to document the new single-host deployment model.

## Result

- AWS validates the simplified template successfully.
- Stack creation no longer hangs waiting for instance bootstrap health signaling.
- The deployment path is now a smaller, lower-cost single-host AWS footprint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guide to reflect simplified infrastructure architecture.

* **Chores**
  * Streamlined CloudFormation configuration by removing DNS and SSL certificate requirements.
  * Simplified instance access using AWS Systems Manager Session Manager.
  * Enhanced bootstrap script for improved reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->