### PR TITLE
Fix CloudFormation bootstrap visibility

### DIFF
--- a/infra/aws/cloudformation/README.md
+++ b/infra/aws/cloudformation/README.md
@@ -76,6 +76,12 @@ These actions are the complete manual pre-launch workflow for this feature.
 4. Start an SSM session using the `SsmStartSessionCommand` output.
 5. Confirm the app starts with `PERSISTENCE_PROVIDER=dynamodb`, `DYNAMODB_REGION`, and `DYNAMODB_TABLE_PREFIX`.
 
+When inspecting the instance over SSM:
+
+- `/etc/payslip4all/payslip4all.env` is written with mode `0600`, so read it with `sudo`.
+- The systemd unit lives at `/etc/systemd/system/payslip4all.service`.
+- Bootstrap output is appended to `/var/log/payslip4all-bootstrap.log`; if the unit file is missing, also inspect `/var/log/cloud-init-output.log`.
+
 ## Cost notes
 
 This deployment is optimized for lower cost than the previous ALB-based version.

--- a/infra/aws/cloudformation/payslip4all-web.yaml
+++ b/infra/aws/cloudformation/payslip4all-web.yaml
@@ -122,6 +122,8 @@ Resources:
         Fn::Base64: !Sub |
           #!/usr/bin/env bash
           set -euo pipefail
+          exec > >(tee -a /var/log/payslip4all-bootstrap.log) 2>&1
+          trap 'echo "Payslip4All bootstrap failed at line $LINENO" >&2' ERR
           APP_ROOT="/opt/payslip4all"
           APP_USER="payslip4all"
           ENV_DIR="/etc/payslip4all"
@@ -132,10 +134,6 @@ Resources:
             useradd --system --home "$APP_ROOT" --shell /sbin/nologin "$APP_USER"
           fi
           mkdir -p "$APP_ROOT" "$ENV_DIR"
-          install -m 0600 /dev/null "$ENV_FILE"
-          curl --fail --location --silent --show-error "${ArtifactSource}" --output /tmp/payslip4all.tgz
-          find "$APP_ROOT" -mindepth 1 -exec rm -rf -- {} +
-          tar -xzf /tmp/payslip4all.tgz -C "$APP_ROOT"
           cat > "$ENV_FILE" <<EOF
           ASPNETCORE_ENVIRONMENT=Production
           ASPNETCORE_URLS=http://0.0.0.0:80
@@ -166,6 +164,9 @@ Resources:
           [Install]
           WantedBy=multi-user.target
           EOF
+          curl --fail --location --silent --show-error "${ArtifactSource}" --output /tmp/payslip4all.tgz
+          find "$APP_ROOT" -mindepth 1 -exec rm -rf -- {} +
+          tar -xzf /tmp/payslip4all.tgz -C "$APP_ROOT"
           chown -R "$APP_USER:$APP_USER" "$APP_ROOT" "$ENV_DIR"
           systemctl daemon-reload
           systemctl enable payslip4all.service

--- a/infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh
+++ b/infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+exec > >(tee -a /var/log/payslip4all-bootstrap.log) 2>&1
+trap 'echo "Payslip4All bootstrap failed at line $LINENO" >&2' ERR
 
 APP_ROOT="/opt/payslip4all"
 APP_USER="payslip4all"
@@ -15,17 +17,13 @@ DYNAMODB_TABLE_PREFIX="${DYNAMODB_TABLE_PREFIX:-payslip4all}"
 DYNAMODB_ENABLE_PITR="${DYNAMODB_ENABLE_PITR:-true}"
 HOSTED_PAYMENTS_SECRET_ARN="${HOSTED_PAYMENTS_SECRET_ARN:-}"
 
+dnf install -y curl tar gzip jq awscli aspnetcore-runtime-8.0
+
 if ! id "$APP_USER" >/dev/null 2>&1; then
   useradd --system --home "$APP_ROOT" --shell /sbin/nologin "$APP_USER"
 fi
 
-dnf install -y curl tar gzip jq awscli aspnetcore-runtime-8.0
-
 mkdir -p "$APP_ROOT" "$ENV_DIR"
-install -m 0600 /dev/null "$ENV_FILE"
-curl --fail --location --silent --show-error "${ARTIFACT_SOURCE}" --output /tmp/payslip4all.tgz
-find "$APP_ROOT" -mindepth 1 -exec rm -rf -- {} +
-tar -xzf /tmp/payslip4all.tgz -C "$APP_ROOT"
 
 cat > "$ENV_FILE" <<EOF
 ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT}
@@ -45,8 +43,6 @@ if [[ -n "${HOSTED_PAYMENTS_SECRET_ARN}" ]]; then
     --output text | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$ENV_FILE"
 fi
 
-chown -R "$APP_USER:$APP_USER" "$APP_ROOT" "$ENV_DIR"
-
 cat > "$SERVICE_FILE" <<EOF
 [Unit]
 Description=Payslip4All web application
@@ -65,6 +61,12 @@ RestartSec=5
 [Install]
 WantedBy=multi-user.target
 EOF
+
+curl --fail --location --silent --show-error "${ARTIFACT_SOURCE}" --output /tmp/payslip4all.tgz
+find "$APP_ROOT" -mindepth 1 -exec rm -rf -- {} +
+tar -xzf /tmp/payslip4all.tgz -C "$APP_ROOT"
+
+chown -R "$APP_USER:$APP_USER" "$APP_ROOT" "$ENV_DIR"
 
 systemctl daemon-reload
 systemctl enable payslip4all.service


### PR DESCRIPTION
## Summary
- write the env and systemd unit before artifact download so bootstrap leaves operator-visible files behind
- add bootstrap logging to /var/log/payslip4all-bootstrap.log for easier instance troubleshooting
- document sudo access and log locations for SSM troubleshooting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added operational troubleshooting guide for instance inspection and log review during support sessions.

* **Chores**
  * Improved deployment process with enhanced logging, error reporting with line numbers, and optimized setup sequencing for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->