### PR TITLE
Add nginx HTTPS reverse proxy deployment

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -1,6 +1,6 @@
 # payslip4all Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-05
+Auto-generated from all feature plans. Last updated: 2026-04-19
 
 ## Active Technologies
 - C# 12 / .NET 8 (LTS) + Blazor Server (ASP.NET Core 8), Entity Framework Core 8, QuestPDF 2024.10.4, BCrypt.Net-Next 4.0.3, Pomelo.EntityFrameworkCore.MySql 8.0.2 (001-payslip-generation)
@@ -47,6 +47,8 @@ Auto-generated from all feature plans. Last updated: 2026-04-05
 - SQLite for local relational development, MySQL/other EF Core relational providers in supported deployments, and DynamoDB when `PERSISTENCE_PROVIDER=dynamodb`; payment audit data is persisted as wallet top-up attempts, payment return evidence, normalization decisions, unmatched return records, wallets, and wallet activities (009-payfast-card-integration)
 - C# 12 on .NET 8 / ASP.NET Core 8 Blazor Web App + ASP.NET Core Blazor Server, Entity Framework Core 8, `AWSSDK.DynamoDBv2`, Serilog, xUnit, bUnit, Moq, PayFast hosted-payment integration (009-payfast-card-integration)
 - SQLite/MySQL via EF Core migrations; DynamoDB via repository implementations and startup table verification when `PERSISTENCE_PROVIDER=dynamodb` (009-payfast-card-integration)
+- nginx configuration, Bash bootstrap scripting, and existing C# 12 / .NET 8 application runtime + nginx, ASP.NET Core 8 reverse-proxy support, AWS CloudFormation/EC2/Secrets Manager deployment assets, Serilog request logging, xUnit + WebApplicationFactory (013-nginx-https-proxy)
+- N/A (no application persistence or schema changes) (013-nginx-https-proxy)
 
 - C# 12 / .NET 8 (LTS) + ASP.NET Core Blazor Server, Entity Framework Core 8, QuestPDF, BCrypt.Net-Next, Pomelo.EntityFrameworkCore.MySql, Microsoft.EntityFrameworkCore.Sqlite, bUnit, xUnit, Moq (001-payslip-generation)
 
@@ -67,9 +69,9 @@ tests/
 C# 12 / .NET 8 (LTS): Follow standard conventions
 
 ## Recent Changes
+- 013-nginx-https-proxy: Added nginx configuration, Bash bootstrap scripting, and existing C# 12 / .NET 8 application runtime + nginx, ASP.NET Core 8 reverse-proxy support, AWS CloudFormation/EC2/Secrets Manager deployment assets, Serilog request logging, xUnit + WebApplicationFactory
 - 009-payfast-card-integration: Added C# 12 on .NET 8 / ASP.NET Core 8 Blazor Web App + ASP.NET Core Blazor Server, Entity Framework Core 8, `AWSSDK.DynamoDBv2`, Serilog, xUnit, bUnit, Moq, PayFast hosted-payment integration
 - 009-payfast-card-integration: Added C# 12 on .NET 8 (`net8.0`) + ASP.NET Core 8 Blazor Server, Entity Framework Core 8, `AWSSDK.DynamoDBv2`, Serilog, `IHttpClientFactory`, PayFast hosted checkout integration
-- 009-payfast-card-integration: Added C# / .NET 8 + ASP.NET Core Blazor Server, Entity Framework Core 8, AWSSDK.DynamoDBv2, Serilog, xUnit, Moq, bUnit, BCrypt.Net-Next, QuestPDF
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/README.md
+++ b/README.md
@@ -158,26 +158,27 @@ credentials, instance metadata, `AWS_PROFILE`, or shared credentials files).
 Payslip4All includes a repository-owned AWS deployment guide for a low-cost hosted setup using:
 
 - one EC2 instance for the web application,
-- one Application Load Balancer for public HTTPS access,
-- Route 53 aliasing for `payslip4all.co.za`,
+- nginx on the EC2 host for public HTTPS access at `payslip4all.co.za`,
+- one Elastic IP that you point the public DNS record at,
 - DynamoDB persistence with hosted AWS point-in-time recovery backups.
 
 Start with:
 
+- nginx operator guide: `infra/nginx/README.md`
 - template: `infra/aws/cloudformation/payslip4all-web.yaml`
 - operator guide: `infra/aws/cloudformation/README.md`
 
 The deployment guide keeps the operator workflow intentionally small:
 
 1. publish the application artifact,
-2. confirm ACM certificate issuance,
-3. confirm Route 53 authority for `payslip4all.co.za`,
+2. stage the nginx certificate secret externally,
+3. point `payslip4all.co.za` at the hosted Elastic IP,
 4. gather external secret references,
 5. launch the CloudFormation stack.
 
-Operators then verify deployment success using the documented signal set: `ApplicationUrl`, `InstanceId`, `LoadBalancerArn`, `InstanceSecurityGroupId`, `LoadBalancerSecurityGroupId`, `BackupProtectionMode`, ALB target health, and the public `/health` endpoint.
+Operators then verify deployment success using the documented signal set: `ApplicationUrl`, `ElasticIpAddress`, `InstanceId`, `InstanceSecurityGroupId`, `SsmStartSessionCommand`, `TlsCertificateSecretReference`, `BackupProtectionMode`, the public `/health` endpoint, and the HTTP→HTTPS redirect.
 
-This deployment path is designed to use as much of the AWS free tier as practical, but it is not fully free-tier-only because the ALB and Route 53 are required paid services for the requested public-domain setup.
+This deployment path is designed to use as much of the AWS free tier as practical while keeping the public edge repository-owned through nginx instead of relying on an ALB, Route 53, or ACM.
 
 ### First-run walkthrough
 

--- a/infra/aws/cloudformation/README.md
+++ b/infra/aws/cloudformation/README.md
@@ -1,12 +1,12 @@
 # AWS CloudFormation Deployment
 
-This guide describes the repository-owned AWS deployment path for Payslip4All using a single EC2 instance, an Elastic IP, SSM Session Manager access, and DynamoDB.
+This guide describes the repository-owned AWS deployment path for Payslip4All using a single EC2 instance, nginx, an Elastic IP, SSM Session Manager access, and DynamoDB.
 
 ## What this deployment creates
 
 - One EC2 web host for Payslip4All
 - One Elastic IP attached directly to the EC2 instance
-- One security group that exposes HTTP on port 80
+- One security group that exposes nginx on ports `80` and `443`
 - One IAM instance profile so the app can use the AWS SDK credential chain and SSM Session Manager
 - A DynamoDB-backed runtime with `PERSISTENCE_PROVIDER=dynamodb`
 - Automated DynamoDB point-in-time recovery for regular backups in hosted AWS
@@ -26,6 +26,7 @@ You must prepare these values before launching the stack:
 | `ArtifactSource` | Points the bootstrap process at the published Payslip4All bundle |
 | `DynamoDbTablePrefix` | Namespaces the application-owned table set |
 | `HostedPaymentsSecretArn` | Optional secret reference for hosted-payment and app-specific configuration |
+| `TlsCertificateSecretArn` | External TLS certificate secret that supplies the nginx `fullchainPem` and `privkeyPem` values |
 
 ## Runtime environment variables
 
@@ -35,66 +36,72 @@ The EC2 bootstrap process writes these values into the service environment:
 - `DYNAMODB_REGION` set from the stack region
 - `DYNAMODB_TABLE_PREFIX`
 - `DYNAMODB_ENABLE_PITR=true`
-- `ASPNETCORE_URLS=http://0.0.0.0:80`
+- `ASPNETCORE_URLS=http://127.0.0.1:8080`
 
 If `HostedPaymentsSecretArn` is provided, the instance also appends the secret values to the app environment file using AWS Secrets Manager. Keep reusable secrets out of the template itself.
 
 ## Architecture and traffic flow
 
 1. An Elastic IP is attached directly to the EC2 instance.
-2. Public HTTP traffic reaches the app on port 80.
-3. Operators connect to the instance through SSM Session Manager instead of SSH.
-4. The web app starts with `PERSISTENCE_PROVIDER=dynamodb`, then provisions and uses the application-owned DynamoDB tables.
+2. Public HTTP and HTTPS traffic reaches nginx on ports `80` and `443`.
+3. nginx redirects `http://payslip4all.co.za` to `https://payslip4all.co.za`.
+4. nginx terminates TLS and reverse-proxies requests to the app on `127.0.0.1:8080`.
+5. Operators connect to the instance through SSM Session Manager instead of SSH.
+6. The web app starts with `PERSISTENCE_PROVIDER=dynamodb`, then provisions and uses the application-owned DynamoDB tables.
 
-The EC2 instance uses a `Name` tag such as `payslip4all-web-prod`. This template intentionally avoids Route 53, ACM, and Application Load Balancer resources so stack creation stays as small and direct as possible.
+This is a no-ALB, no-Route53, no-ACM deployment flow. DNS publishing for `payslip4all.co.za` and certificate delivery are handled outside the stack so the public edge stays small and repository-owned.
 
 ## Operator-visible signals
 
 Operators should verify the deployment with this explicit signal set:
 
-- CloudFormation outputs: `ApplicationUrl`, `ElasticIpAddress`, `InstanceId`, `InstanceSecurityGroupId`, `SsmStartSessionCommand`, `HostedPaymentsSecretReference`, `BackupProtectionMode`, and `RestoreRunbook`
-- The public `/health` endpoint through the Elastic IP
-- The `Name` tag on the EC2 instance
+- CloudFormation outputs: `ApplicationUrl`, `ElasticIpAddress`, `InstanceId`, `InstanceSecurityGroupId`, `SsmStartSessionCommand`, `HostedPaymentsSecretReference`, `TlsCertificateSecretReference`, `NginxConfigPath`, `BackupProtectionMode`, and `RestoreRunbook`
+- `https://payslip4all.co.za/health`
+- the `http://payslip4all.co.za` redirect to HTTPS
+- successful `nginx -t` validation on the host
+- the `Name` tag on the EC2 instance
 - SSM Session Manager access to the instance
 
-These signals are intentionally minimal: enough to verify stack identity, app reachability, operator access, and backup posture without turning this feature into a separate platform project.
+These signals are intentionally minimal: enough to verify stack identity, secure app reachability, operator access, and backup posture without turning this feature into a separate platform project.
 
-## Manual pre-launch actions
+## Five manual pre-launch actions
 
 1. Publish or upload the application artifact that `ArtifactSource` will reference.
-2. Confirm the chosen subnet is public and has outbound internet access.
-3. Gather the external secret references required for hosted-payment and application runtime configuration.
-4. Launch `infra/aws/cloudformation/payslip4all-web.yaml` with the required parameters.
-
-These actions are the complete manual pre-launch workflow for this feature.
+2. Stage the TLS certificate secret for nginx so it exposes `fullchainPem` and `privkeyPem`.
+3. Reserve or confirm the Elastic IP workflow, then point `payslip4all.co.za` at that public address.
+4. Gather the external secret references required for hosted-payment and application runtime configuration.
+5. Launch `infra/aws/cloudformation/payslip4all-web.yaml` with the required parameters.
 
 ## Post-launch verification
 
 1. Wait for the stack to complete.
-2. Open the `ApplicationUrl` output.
+2. Open the `ApplicationUrl` output after DNS for `payslip4all.co.za` is live.
 3. Confirm the instance responds on `/health`.
-4. Start an SSM session using the `SsmStartSessionCommand` output.
-5. Confirm the app starts with `PERSISTENCE_PROVIDER=dynamodb`, `DYNAMODB_REGION`, and `DYNAMODB_TABLE_PREFIX`.
+4. Confirm `http://payslip4all.co.za` redirects once to `https://payslip4all.co.za`.
+5. Start an SSM session using the `SsmStartSessionCommand` output.
+6. Run `nginx -t`.
+7. Confirm the app starts with `PERSISTENCE_PROVIDER=dynamodb`, `DYNAMODB_REGION`, `DYNAMODB_TABLE_PREFIX`, and `ASPNETCORE_URLS=http://127.0.0.1:8080`.
 
 ## Cost notes
 
-This deployment is optimized for lower cost than the previous ALB-based version.
+This deployment is optimized for lower cost than the previous managed-edge version.
 
 - The template defaults to a small EC2 instance type to use as much of the free tier as practical.
 - DynamoDB uses the app's on-demand table model, which is cost-efficient for low traffic.
-- The template no longer creates an Application Load Balancer or Route 53 record.
-- The main recurring costs are the EC2 instance, Elastic IP while attached, any EBS storage, and any DynamoDB traffic or backup storage above the free tier.
+- The template avoids managed edge services by following the no-ALB, no-Route53, no-ACM pattern.
+- The main recurring costs are the EC2 instance, Elastic IP while attached, any EBS storage, any DynamoDB traffic or backup storage above the free tier, and the operator-managed certificate workflow.
 
 ## Health checks and startup validation
 
 - Stack creation completes once AWS creates the instance resources; application bootstrap continues on the instance after launch.
-- The web app enables request logging so direct instance traffic is visible in structured application logs.
-- Startup fails fast if the DynamoDB configuration is incomplete at runtime.
+- nginx owns the public edge while the app stays local to `127.0.0.1:8080`.
+- `nginx -t` must pass before nginx is restarted.
+- Startup fails fast if the DynamoDB configuration or TLS secret wiring is incomplete at runtime.
 - The preferred hosted AWS path uses the IAM instance profile, not static AWS credentials.
 
 ## Replaceable compute behaviour
 
-The CloudFormation stack keeps application data in DynamoDB and keeps the public endpoint stable through the Elastic IP. Updating the stack and replacing or recreating the EC2 instance should therefore keep application data available and restore the same public endpoint once the replacement instance boots successfully and the Elastic IP is attached.
+The CloudFormation stack keeps application data in DynamoDB and keeps the public endpoint stable through the Elastic IP. Updating the stack and replacing or recreating the EC2 instance should therefore keep application data available and restore the same public endpoint once the replacement instance boots successfully, the certificate secret is restaged, and the Elastic IP is attached. The public entry point remains the same when the instance is replaced correctly.
 
 ## DynamoDB backup and restore
 
@@ -118,9 +125,9 @@ The hosted AWS deployment enables **point-in-time recovery** so the Payslip4All 
 
 After launch:
 
-1. Browse to the `ApplicationUrl` output.
-2. Confirm `/health` returns a healthy response through the Elastic IP.
-3. Confirm the EC2 instance is tagged with a payslip4all-derived name.
-4. Confirm SSM Session Manager can open a shell on the instance.
-5. Confirm the app starts with `PERSISTENCE_PROVIDER=dynamodb`, `DYNAMODB_REGION`, and `DYNAMODB_TABLE_PREFIX`.
-6. Confirm the hosted AWS environment reports point-in-time recovery enabled for the Payslip4All tables.
+1. Browse to `https://payslip4all.co.za`.
+2. Confirm `/health` returns a healthy response through nginx.
+3. Confirm the HTTP endpoint redirects to HTTPS in one step.
+4. Confirm the EC2 instance is tagged with a payslip4all-derived name.
+5. Confirm SSM Session Manager can open a shell on the instance.
+6. Confirm the app starts with `PERSISTENCE_PROVIDER=dynamodb`, `DYNAMODB_REGION`, `DYNAMODB_TABLE_PREFIX`, and `ASPNETCORE_URLS=http://127.0.0.1:8080`.

--- a/infra/aws/cloudformation/payslip4all-web.yaml
+++ b/infra/aws/cloudformation/payslip4all-web.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: Deploy Payslip4All to AWS on a single EC2 instance with an Elastic IP and DynamoDB persistence.
+Description: Deploy Payslip4All behind nginx on a single EC2 instance with an Elastic IP and DynamoDB persistence.
 
 Parameters:
   EnvironmentName:
@@ -27,17 +27,25 @@ Parameters:
     Type: String
     Default: ''
     Description: Optional Secrets Manager ARN that stores hosted-payment and app secrets.
+  TlsCertificateSecretArn:
+    Type: String
+    Default: ''
+    Description: Secrets Manager ARN whose SecretString JSON contains fullchainPem and privkeyPem for nginx TLS.
 
 Resources:
   InstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: Public ingress for the Payslip4All EC2 host.
+      GroupDescription: Public ingress for the Payslip4All nginx host.
       VpcId: !Ref VpcId
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
           CidrIp: 0.0.0.0/0
       SecurityGroupEgress:
         - IpProtocol: -1
@@ -94,6 +102,13 @@ Resources:
                     - secretsmanager:GetSecretValue
                   Resource: !Ref HostedPaymentsSecretArn
                 - !Ref AWS::NoValue
+              - !If
+                - HasTlsCertificateSecret
+                - Effect: Allow
+                  Action:
+                    - secretsmanager:GetSecretValue
+                  Resource: !Ref TlsCertificateSecretArn
+                - !Ref AWS::NoValue
       Tags:
         - Key: Name
           Value: !Sub payslip4all-web-role-${EnvironmentName}
@@ -127,33 +142,45 @@ Resources:
           ENV_DIR="/etc/payslip4all"
           ENV_FILE="$ENV_DIR/payslip4all.env"
           SERVICE_FILE="/etc/systemd/system/payslip4all.service"
-          dnf install -y curl tar gzip jq awscli aspnetcore-runtime-8.0
+          NGINX_CERT_DIR="/etc/nginx/certs"
+          NGINX_SITE_CONFIG="/etc/nginx/conf.d/payslip4all.conf"
+          PUBLIC_DOMAIN="payslip4all.co.za"
+          UPSTREAM_APP_URL="http://127.0.0.1:8080"
+          dnf install -y curl tar gzip jq awscli aspnetcore-runtime-8.0 nginx
           if ! id "$APP_USER" >/dev/null 2>&1; then
             useradd --system --home "$APP_ROOT" --shell /sbin/nologin "$APP_USER"
           fi
-          mkdir -p "$APP_ROOT" "$ENV_DIR"
+          mkdir -p "$APP_ROOT" "$ENV_DIR" "$NGINX_CERT_DIR"
           install -m 0600 /dev/null "$ENV_FILE"
           curl --fail --location --silent --show-error "${ArtifactSource}" --output /tmp/payslip4all.tgz
           find "$APP_ROOT" -mindepth 1 -exec rm -rf -- {} +
           tar -xzf /tmp/payslip4all.tgz -C "$APP_ROOT"
           cat > "$ENV_FILE" <<EOF
           ASPNETCORE_ENVIRONMENT=Production
-          ASPNETCORE_URLS=http://0.0.0.0:80
+          ASPNETCORE_URLS=http://127.0.0.1:8080
           PERSISTENCE_PROVIDER=dynamodb
           DYNAMODB_REGION=${AWS::Region}
           DYNAMODB_TABLE_PREFIX=${DynamoDbTablePrefix}
           DYNAMODB_ENABLE_PITR=true
           EOF
-          chmod 600 "$ENV_FILE"
           if [[ -n "${HostedPaymentsSecretArn}" ]]; then
             aws secretsmanager get-secret-value --secret-id "${HostedPaymentsSecretArn}" --query SecretString --output text | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$ENV_FILE"
           fi
+          if [[ -z "${TlsCertificateSecretArn}" ]]; then
+            echo "TlsCertificateSecretArn must reference a Secrets Manager secret containing fullchainPem and privkeyPem." >&2
+            exit 1
+          fi
+          CERTIFICATE_JSON="$(aws secretsmanager get-secret-value --secret-id "${TlsCertificateSecretArn}" --query SecretString --output text)"
+          printf '%s' "$CERTIFICATE_JSON" | jq -r '.fullchainPem' > "$NGINX_CERT_DIR/fullchain.pem"
+          printf '%s' "$CERTIFICATE_JSON" | jq -r '.privkeyPem' > "$NGINX_CERT_DIR/privkey.pem"
+          chmod 600 "$ENV_FILE" "$NGINX_CERT_DIR/privkey.pem"
+          chmod 644 "$NGINX_CERT_DIR/fullchain.pem"
           cat > "$SERVICE_FILE" <<EOF
           [Unit]
           Description=Payslip4All web application
           After=network-online.target
           Wants=network-online.target
-
+          
           [Service]
           Type=simple
           User=$APP_USER
@@ -162,14 +189,104 @@ Resources:
           ExecStart=/usr/bin/dotnet $APP_ROOT/Payslip4All.Web.dll
           Restart=always
           RestartSec=5
-
+          
           [Install]
           WantedBy=multi-user.target
           EOF
+          cat > "$NGINX_SITE_CONFIG" <<EOF
+          map \$http_upgrade \$connection_upgrade {
+              default upgrade;
+              '' close;
+          }
+          
+          upstream payslip4all_app {
+              server 127.0.0.1:8080;
+              keepalive 32;
+          }
+          
+          server {
+              listen 80 default_server;
+              server_name _;
+          
+              return 421;
+          }
+          
+          server {
+              listen 80;
+              server_name payslip4all.co.za;
+          
+              return 301 https://payslip4all.co.za\$request_uri;
+          }
+          
+          server {
+              listen 443 ssl default_server;
+              server_name _;
+          
+              ssl_certificate /etc/nginx/certs/fullchain.pem;
+              ssl_certificate_key /etc/nginx/certs/privkey.pem;
+          
+              return 421;
+          }
+          
+          server {
+              listen 443 ssl http2;
+              server_name payslip4all.co.za;
+          
+              ssl_certificate /etc/nginx/certs/fullchain.pem;
+              ssl_certificate_key /etc/nginx/certs/privkey.pem;
+              ssl_session_timeout 1d;
+              ssl_session_cache shared:SSL:10m;
+              ssl_protocols TLSv1.2 TLSv1.3;
+              server_tokens off;
+          
+              proxy_intercept_errors on;
+              error_page 502 503 504 =503 /503.html;
+          
+              location = /health {
+                  proxy_http_version 1.1;
+                  proxy_connect_timeout 5s;
+                  proxy_send_timeout 10s;
+                  proxy_read_timeout 10s;
+                  proxy_pass http://payslip4all_app;
+                  proxy_set_header Host \$host;
+                  proxy_set_header X-Real-IP \$remote_addr;
+                  proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto https;
+                  proxy_set_header X-Forwarded-Host \$host;
+              }
+          
+              location / {
+                  proxy_http_version 1.1;
+                  proxy_connect_timeout 5s;
+                  proxy_send_timeout 60s;
+                  proxy_read_timeout 300s;
+                  proxy_buffering off;
+                  proxy_pass http://payslip4all_app;
+                  proxy_set_header Host \$host;
+                  proxy_set_header X-Real-IP \$remote_addr;
+                  proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto https;
+                  proxy_set_header X-Forwarded-Host \$host;
+                  proxy_set_header Upgrade \$http_upgrade;
+                  proxy_set_header Connection \$connection_upgrade;
+              }
+          
+              location = /503.html {
+                  internal;
+                  default_type text/plain;
+                  return 503 "Service temporarily unavailable.\n";
+              }
+          }
+          EOF
+          chmod 644 "$NGINX_SITE_CONFIG"
           chown -R "$APP_USER:$APP_USER" "$APP_ROOT" "$ENV_DIR"
           systemctl daemon-reload
           systemctl enable payslip4all.service
+          systemctl enable nginx
           systemctl restart payslip4all.service
+          systemctl is-active --quiet payslip4all.service
+          nginx -t
+          systemctl restart nginx
       Tags:
         - Key: Name
           Value: !Sub payslip4all-web-${EnvironmentName}
@@ -185,11 +302,12 @@ Resources:
 
 Conditions:
   HasHostedPaymentsSecret: !Not [!Equals [!Ref HostedPaymentsSecretArn, '']]
+  HasTlsCertificateSecret: !Not [!Equals [!Ref TlsCertificateSecretArn, '']]
 
 Outputs:
   ApplicationUrl:
-    Description: Public HTTP URL for Payslip4All.
-    Value: !Sub http://${ElasticIp}
+    Description: Public HTTPS URL for Payslip4All.
+    Value: https://payslip4all.co.za
   ElasticIpAddress:
     Description: Elastic IP address assigned to the EC2 instance.
     Value: !Ref ElasticIp
@@ -208,6 +326,15 @@ Outputs:
       - HasHostedPaymentsSecret
       - !Ref HostedPaymentsSecretArn
       - no-external-secret-configured
+  TlsCertificateSecretReference:
+    Description: Secret reference used to stage nginx TLS certificate material on the host.
+    Value: !If
+      - HasTlsCertificateSecret
+      - !Ref TlsCertificateSecretArn
+      - no-tls-secret-configured
+  NginxConfigPath:
+    Description: Repository path of the nginx gateway definition.
+    Value: infra/nginx/payslip4all.conf
   BackupProtectionMode:
     Description: DynamoDB backup protection mode for hosted AWS.
     Value: point-in-time recovery via hosted service

--- a/infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh
+++ b/infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh
@@ -6,6 +6,10 @@ APP_USER="payslip4all"
 ENV_DIR="/etc/payslip4all"
 ENV_FILE="$ENV_DIR/payslip4all.env"
 SERVICE_FILE="/etc/systemd/system/payslip4all.service"
+NGINX_CERT_DIR="/etc/nginx/certs"
+NGINX_SITE_CONFIG="/etc/nginx/conf.d/payslip4all.conf"
+PUBLIC_DOMAIN="${PUBLIC_DOMAIN:-payslip4all.co.za}"
+UPSTREAM_APP_URL="${UPSTREAM_APP_URL:-http://127.0.0.1:8080}"
 
 ARTIFACT_SOURCE="${ARTIFACT_SOURCE:?ARTIFACT_SOURCE is required}"
 ASPNETCORE_ENVIRONMENT="${ASPNETCORE_ENVIRONMENT:-Production}"
@@ -14,14 +18,17 @@ DYNAMODB_REGION="${DYNAMODB_REGION:?DYNAMODB_REGION is required}"
 DYNAMODB_TABLE_PREFIX="${DYNAMODB_TABLE_PREFIX:-payslip4all}"
 DYNAMODB_ENABLE_PITR="${DYNAMODB_ENABLE_PITR:-true}"
 HOSTED_PAYMENTS_SECRET_ARN="${HOSTED_PAYMENTS_SECRET_ARN:-}"
+TLS_CERTIFICATE_SECRET_ARN="${TLS_CERTIFICATE_SECRET_ARN:?TLS_CERTIFICATE_SECRET_ARN is required}"
+TLS_CERTIFICATE_FULLCHAIN_KEY="${TLS_CERTIFICATE_FULLCHAIN_KEY:-fullchainPem}"
+TLS_PRIVATE_KEY_KEY="${TLS_PRIVATE_KEY_KEY:-privkeyPem}"
 
 if ! id "$APP_USER" >/dev/null 2>&1; then
   useradd --system --home "$APP_ROOT" --shell /sbin/nologin "$APP_USER"
 fi
 
-dnf install -y curl tar gzip jq awscli aspnetcore-runtime-8.0
+dnf install -y curl tar gzip jq awscli aspnetcore-runtime-8.0 nginx
 
-mkdir -p "$APP_ROOT" "$ENV_DIR"
+mkdir -p "$APP_ROOT" "$ENV_DIR" "$NGINX_CERT_DIR"
 install -m 0600 /dev/null "$ENV_FILE"
 curl --fail --location --silent --show-error "${ARTIFACT_SOURCE}" --output /tmp/payslip4all.tgz
 find "$APP_ROOT" -mindepth 1 -exec rm -rf -- {} +
@@ -29,14 +36,12 @@ tar -xzf /tmp/payslip4all.tgz -C "$APP_ROOT"
 
 cat > "$ENV_FILE" <<EOF
 ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT}
-ASPNETCORE_URLS=http://0.0.0.0:80
+ASPNETCORE_URLS=http://127.0.0.1:8080
 PERSISTENCE_PROVIDER=${PERSISTENCE_PROVIDER}
 DYNAMODB_REGION=${DYNAMODB_REGION}
 DYNAMODB_TABLE_PREFIX=${DYNAMODB_TABLE_PREFIX}
 DYNAMODB_ENABLE_PITR=${DYNAMODB_ENABLE_PITR}
 EOF
-
-chmod 600 "$ENV_FILE"
 
 if [[ -n "${HOSTED_PAYMENTS_SECRET_ARN}" ]]; then
   aws secretsmanager get-secret-value \
@@ -45,7 +50,16 @@ if [[ -n "${HOSTED_PAYMENTS_SECRET_ARN}" ]]; then
     --output text | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$ENV_FILE"
 fi
 
-chown -R "$APP_USER:$APP_USER" "$APP_ROOT" "$ENV_DIR"
+CERTIFICATE_JSON="$(aws secretsmanager get-secret-value \
+  --secret-id "${TLS_CERTIFICATE_SECRET_ARN}" \
+  --query SecretString \
+  --output text)"
+
+printf '%s' "$CERTIFICATE_JSON" | jq -r --arg key "$TLS_CERTIFICATE_FULLCHAIN_KEY" '.[$key]' > "$NGINX_CERT_DIR/fullchain.pem"
+printf '%s' "$CERTIFICATE_JSON" | jq -r --arg key "$TLS_PRIVATE_KEY_KEY" '.[$key]' > "$NGINX_CERT_DIR/privkey.pem"
+
+chmod 600 "$ENV_FILE" "$NGINX_CERT_DIR/privkey.pem"
+chmod 644 "$NGINX_CERT_DIR/fullchain.pem"
 
 cat > "$SERVICE_FILE" <<EOF
 [Unit]
@@ -66,6 +80,99 @@ RestartSec=5
 WantedBy=multi-user.target
 EOF
 
+cat > "$NGINX_SITE_CONFIG" <<EOF
+map \$http_upgrade \$connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
+upstream payslip4all_app {
+    server 127.0.0.1:8080;
+    keepalive 32;
+}
+
+server {
+    listen 80 default_server;
+    server_name _;
+
+    return 421;
+}
+
+server {
+    listen 80;
+    server_name ${PUBLIC_DOMAIN};
+
+    return 301 https://${PUBLIC_DOMAIN}\$request_uri;
+}
+
+server {
+    listen 443 ssl default_server;
+    server_name _;
+
+    ssl_certificate ${NGINX_CERT_DIR}/fullchain.pem;
+    ssl_certificate_key ${NGINX_CERT_DIR}/privkey.pem;
+
+    return 421;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name ${PUBLIC_DOMAIN};
+
+    ssl_certificate ${NGINX_CERT_DIR}/fullchain.pem;
+    ssl_certificate_key ${NGINX_CERT_DIR}/privkey.pem;
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:10m;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    server_tokens off;
+
+    proxy_intercept_errors on;
+    error_page 502 503 504 =503 /503.html;
+
+    location = /health {
+        proxy_http_version 1.1;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 10s;
+        proxy_read_timeout 10s;
+        proxy_pass ${UPSTREAM_APP_URL};
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host \$host;
+    }
+
+    location / {
+        proxy_http_version 1.1;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 300s;
+        proxy_buffering off;
+        proxy_pass ${UPSTREAM_APP_URL};
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host \$host;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection \$connection_upgrade;
+    }
+
+    location = /503.html {
+        internal;
+        default_type text/plain;
+        return 503 "Service temporarily unavailable.\n";
+    }
+}
+EOF
+
+chmod 644 "$NGINX_SITE_CONFIG"
+chown -R "$APP_USER:$APP_USER" "$APP_ROOT" "$ENV_DIR"
+
 systemctl daemon-reload
 systemctl enable payslip4all.service
+systemctl enable nginx
 systemctl restart payslip4all.service
+systemctl is-active --quiet payslip4all.service
+nginx -t
+systemctl restart nginx

--- a/infra/nginx/README.md
+++ b/infra/nginx/README.md
@@ -1,0 +1,73 @@
+# Payslip4All nginx gateway
+
+This directory contains the repository-owned nginx gateway definition for serving Payslip4All at `https://payslip4all.co.za`.
+
+## Files
+
+- `infra/nginx/payslip4all.conf` — nginx site configuration for HTTPS termination, HTTP→HTTPS redirect, reverse proxying, host filtering, and generic upstream failure handling.
+- `infra/aws/cloudformation/payslip4all-web.yaml` — the hosted AWS path that installs nginx, stages the same gateway configuration, and publishes the app through an Elastic IP.
+- `infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh` — the standalone bootstrap script that mirrors the hosted AWS nginx setup.
+
+## Fixed gateway behaviour
+
+- Public production host: `payslip4all.co.za`
+- Public listeners: `80` for redirect and `443` for HTTPS
+- Upstream application endpoint: `127.0.0.1:8080`
+- TLS runtime files: `/etc/nginx/certs/fullchain.pem` and `/etc/nginx/certs/privkey.pem`
+- Wrong-host handling: unrelated hosts receive a gateway rejection instead of the production app
+
+## Operator prerequisites
+
+Before activation, confirm:
+
+1. `payslip4all.co.za` can resolve to the target host or hosted AWS Elastic IP.
+2. nginx is installed and can read `/etc/nginx/certs/fullchain.pem` and `/etc/nginx/certs/privkey.pem`.
+3. The Payslip4All app can bind to `127.0.0.1:8080`.
+4. Certificate material is delivered from an external source such as AWS Secrets Manager or another deployment-managed secret/file mechanism.
+
+## Activation inputs
+
+Operators must be able to supply or stage these inputs without committing certificate contents to source control:
+
+| Input | Purpose |
+|-------|---------|
+| `payslip4all.co.za` DNS record | Publishes the fixed production host |
+| `/etc/nginx/certs/fullchain.pem` | Public certificate chain consumed by nginx |
+| `/etc/nginx/certs/privkey.pem` | Private key consumed by nginx |
+| `127.0.0.1:8080` | Local-only upstream used by the app service |
+| Optional AWS Secrets Manager secret | Hosted AWS delivery path for `fullchainPem` and `privkeyPem` values |
+
+## Hosted AWS alignment
+
+The existing hosted AWS path under `infra/aws/cloudformation/` now assumes nginx is the public edge:
+
+- the app service runs with `ASPNETCORE_URLS=http://127.0.0.1:8080`,
+- the EC2 security group exposes only nginx on ports `80` and `443`,
+- bootstrap stages certificate files from an external secret reference,
+- bootstrap validates the generated nginx config with `nginx -t` before restarting services.
+
+## Recommended operator workflow
+
+1. Stage the repository-owned gateway config from `infra/nginx/payslip4all.conf` onto the host (or let the hosted AWS bootstrap render the same content).
+2. Place `fullchain.pem` and `privkey.pem` in `/etc/nginx/certs/`.
+3. Start or restart the Payslip4All app on `127.0.0.1:8080`.
+4. Validate the gateway with `nginx -t`.
+5. Reload nginx and smoke-test `https://payslip4all.co.za` plus the HTTP redirect path.
+
+## Smoke checks
+
+- `https://payslip4all.co.za` returns the application successfully.
+- `http://payslip4all.co.za` redirects once to HTTPS.
+- `https://payslip4all.co.za/health` returns the app health payload.
+- Interactive Blazor Server flows continue to work through forwarded headers and WebSocket upgrade support.
+- wrong-host validation confirms unrelated hostnames are rejected without serving the production app.
+- stopping the upstream returns a generic `503 Service temporarily unavailable.` response that does not disclose `127.0.0.1:8080`.
+
+## Certificate replacement
+
+Certificate rotation keeps the same public host and nginx routing rules:
+
+1. Replace the external certificate source.
+2. refresh `/etc/nginx/certs/fullchain.pem` and `/etc/nginx/certs/privkey.pem`,
+3. run `nginx -t`,
+4. reload nginx.

--- a/infra/nginx/payslip4all.conf
+++ b/infra/nginx/payslip4all.conf
@@ -1,0 +1,83 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
+upstream payslip4all_app {
+    server 127.0.0.1:8080;
+    keepalive 32;
+}
+
+server {
+    listen 80 default_server;
+    server_name _;
+
+    return 421;
+}
+
+server {
+    listen 80;
+    server_name payslip4all.co.za;
+
+    return 301 https://payslip4all.co.za$request_uri;
+}
+
+server {
+    listen 443 ssl default_server;
+    server_name _;
+
+    ssl_certificate /etc/nginx/certs/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/privkey.pem;
+
+    return 421;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name payslip4all.co.za;
+
+    ssl_certificate /etc/nginx/certs/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/privkey.pem;
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:10m;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    server_tokens off;
+
+    proxy_intercept_errors on;
+    error_page 502 503 504 =503 /503.html;
+
+    location = /health {
+        proxy_http_version 1.1;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 10s;
+        proxy_read_timeout 10s;
+        proxy_pass http://payslip4all_app;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+    }
+
+    location / {
+        proxy_http_version 1.1;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 300s;
+        proxy_buffering off;
+        proxy_pass http://payslip4all_app;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+
+    location = /503.html {
+        internal;
+        default_type text/plain;
+        return 503 "Service temporarily unavailable.\n";
+    }
+}

--- a/specs/013-nginx-https-proxy/checklists/requirements.md
+++ b/specs/013-nginx-https-proxy/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Secure Public Gateway Configuration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-19
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs) — The specification describes a "public gateway configuration" and "upstream application endpoint" rather than file syntax, directives, or code-level implementation.
+- [x] Focused on user value and business needs — User stories describe operator value: secure public access, safe request routing, and reusable deployment governance.
+- [x] Written for non-technical stakeholders — Requirements and outcomes describe observable deployment behaviour without source-code instructions.
+- [x] All mandatory sections completed — Architecture & TDD Alignment, User Stories, Edge Cases, Requirements, Key Entities, Success Criteria, and Assumptions are all populated.
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain — The spec contains no unresolved clarification markers.
+- [x] Requirements are testable and unambiguous — Functional requirements FR-001 through FR-010 each define observable behaviour or artifacts.
+- [x] Success criteria are measurable — SC-001 through SC-005 define time, percentage, and completion metrics.
+- [x] Success criteria are technology-agnostic (no implementation details) — Measurable outcomes refer to operator and user-visible behaviour, not server directives or tool-specific metrics.
+- [x] All acceptance scenarios are defined — Each user story includes complete Given/When/Then scenarios.
+- [x] Edge cases are identified — Edge Cases cover certificate readiness, upstream failure, unexpected hostnames, and credential renewal.
+- [x] Scope is clearly bounded — Assumptions bound the feature to one public host and exclude additional aliases or subdomains unless later requested.
+- [x] Dependencies and assumptions identified — Assumptions identify DNS control, secure-connection material availability, and the existing internal application endpoint.
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria — User stories and acceptance scenarios cover secure access, reverse proxy behaviour, and source-controlled deployment reuse.
+- [x] User scenarios cover primary flows — Primary flows cover secure browsing, public-to-internal request forwarding, and locating/reusing the deployment artifact.
+- [x] Feature meets measurable outcomes defined in Success Criteria — Success criteria align with the secure access, routing, and operability outcomes requested for the feature.
+- [x] No implementation details leak into specification — Aside from the user-provided input quote, the specification avoids server-specific directives and low-level implementation language.
+
+## Notes
+
+- Validation iteration 1 completed with all items passing.
+- Evidence reviewed from: "Architecture & TDD Alignment", "User Story 1 - Serve the public site securely", "User Story 2 - Route public traffic to the running application", "Functional Requirements", and "Measurable Outcomes".
+- No unresolved issues remain before `/speckit.plan`.

--- a/specs/013-nginx-https-proxy/contracts/nginx-gateway-contract.md
+++ b/specs/013-nginx-https-proxy/contracts/nginx-gateway-contract.md
@@ -1,0 +1,79 @@
+# Contract: nginx Gateway for Payslip4All
+
+## Purpose
+
+Define the operator-facing contract for the nginx gateway assets that expose Payslip4All at `payslip4all.co.za` over HTTPS and reverse-proxy traffic to the existing ASP.NET Core app.
+
+## Audience
+
+- Operators deploying or updating the public gateway
+- Maintainers reviewing nginx or AWS deployment changes
+
+## Scope
+
+This contract covers the repository-owned nginx config, its activation prerequisites, the required proxy behavior, and the observable verification conditions. It does not define new business-domain behavior inside Payslip4All.
+
+## Required Inputs
+
+The gateway assets MUST accept or document operator-supplied values for:
+
+| Input | Purpose |
+|-------|---------|
+| TLS certificate reference | Supplies the public certificate chain for `payslip4all.co.za` |
+| TLS private key reference | Supplies the HTTPS private key without committing it to source control |
+| Upstream application address | Identifies the internal Payslip4All endpoint nginx should proxy to |
+| Host bootstrap path | Describes how the config and certificate files are placed on the target host |
+| DNS prerequisite | Ensures `payslip4all.co.za` resolves to the nginx host |
+
+The domain name itself is fixed by this feature and MUST remain `payslip4all.co.za`.
+
+## Required Gateway Behavior
+
+The gateway assets MUST:
+
+1. serve `https://payslip4all.co.za` over TLS,
+2. redirect `http://payslip4all.co.za` to the equivalent HTTPS URL,
+3. reverse-proxy public requests to the configured internal Payslip4All endpoint,
+4. preserve the original request context needed by the app by forwarding `Host`, `X-Forwarded-For`, `X-Forwarded-Proto`, and `X-Forwarded-Host`,
+5. forward WebSocket/upgrade headers required for Blazor Server interactivity,
+6. expose the app's `/health` behavior through the public gateway,
+7. return an unavailable non-success response when the upstream app is down,
+8. avoid exposing the internal app endpoint in user-facing failure responses,
+9. restrict production serving to `payslip4all.co.za` rather than treating arbitrary hostnames as valid production entry points.
+
+## Security Rules
+
+The implementation MUST:
+
+- keep reusable certificate or secret material out of version-controlled plaintext files,
+- make nginx the intended public edge while the app stays on an internal-only endpoint,
+- preserve HTTPS as the normal user path,
+- avoid weakening the existing ASP.NET Core forwarded-header behavior,
+- support certificate replacement without redefining the overall host-routing behavior.
+
+The implementation MUST NOT:
+
+- commit reusable certificate private keys into the repo,
+- expose the internal app port as the public production endpoint,
+- silently serve the production app for unrelated hostnames.
+
+## Deployment & Documentation Rules
+
+The implementation MUST:
+
+- store the primary gateway artifact under `infra/`,
+- document operator prerequisites and activation inputs,
+- stay consistent with the repository's existing `infra/aws/cloudformation/` deployment guidance when hosted on AWS,
+- define smoke-verifiable checks for redirect behavior, HTTPS access, `/health`, host restriction, and upstream failure handling.
+
+## Acceptance Conditions
+
+This contract is satisfied when:
+
+1. an operator can locate the nginx gateway artifact in `infra/`,
+2. the operator can identify the required certificate and upstream activation inputs quickly,
+3. end users reach Payslip4All successfully at `https://payslip4all.co.za`,
+4. insecure requests redirect to HTTPS in one step,
+5. interactive Blazor behavior still works through the proxy,
+6. unrelated hostnames are not treated as the production entry point,
+7. upstream outages return a user-safe unavailable response without leaking internal endpoint details.

--- a/specs/013-nginx-https-proxy/data-model.md
+++ b/specs/013-nginx-https-proxy/data-model.md
@@ -1,0 +1,153 @@
+# Data Model: nginx HTTPS Reverse Proxy
+
+## Overview
+
+This feature does not add business-domain persistence. Its data model describes the operator-facing gateway objects, runtime configuration inputs, and verification states required to serve Payslip4All securely through nginx.
+
+## Entities
+
+### 1. Gateway Site Configuration
+
+**Purpose**: The source-controlled nginx artifact that defines how `payslip4all.co.za` is served publicly.
+
+**Fields**:
+- `domainName` — fixed public hostname (`payslip4all.co.za`)
+- `httpRedirectEnabled` — whether port `80` requests are redirected to HTTPS
+- `httpsListenerEnabled` — whether port `443` serves the site
+- `configPath` — repository path of the nginx config artifact
+- `defaultHostPolicy` — how non-matching hostnames are handled
+- `websocketProxyEnabled` — whether upgrade headers for Blazor Server are enabled
+
+**Relationships**:
+- Uses one `TLS Certificate Binding`
+- Proxies to one `Upstream Application Endpoint`
+- Applies one `Proxy Header Policy`
+- Depends on one `Deployment Prerequisite Set`
+
+**Validation Rules**:
+- `domainName` must remain `payslip4all.co.za` for this feature.
+- Public app serving must not occur for unrelated hostnames.
+- HTTPS and HTTP redirect behavior must both be defined.
+
+### 2. TLS Certificate Binding
+
+**Purpose**: The deployment-managed certificate material that nginx uses for HTTPS.
+
+**Fields**:
+- `certificateReference` — secret or file reference for the public certificate chain
+- `privateKeyReference` — secret or file reference for the TLS private key
+- `targetDirectory` — runtime location such as `/etc/nginx/certs`
+- `rotationMode` — how renewed material is replaced
+- `reloadRequired` — whether nginx must reload after certificate updates
+
+**Relationships**:
+- Secures one `Gateway Site Configuration`
+- Depends on one `Deployment Prerequisite Set`
+
+**Validation Rules**:
+- Certificate material must not be committed to source control.
+- The certificate must cover `payslip4all.co.za`.
+- Rotation must preserve the public domain without redefining gateway behavior.
+
+### 3. Upstream Application Endpoint
+
+**Purpose**: The internal Payslip4All destination that receives proxied traffic from nginx.
+
+**Fields**:
+- `scheme` — planned as `http`
+- `host` — planned as `127.0.0.1`
+- `port` — planned as `8080`
+- `healthPath` — `/health`
+- `localOnlyBinding` — whether the endpoint avoids direct public exposure
+- `availabilityState` — current upstream health state
+
+**Relationships**:
+- Receives traffic from one `Gateway Site Configuration`
+- Is observed by one `Operator Verification Set`
+
+**Validation Rules**:
+- The endpoint must be externally configurable only where needed by deployment tooling.
+- The endpoint must not become the public production address.
+- The health path must remain probeable through the gateway and, where needed, locally.
+
+### 4. Proxy Header Policy
+
+**Purpose**: The set of request headers nginx must preserve or add so the app behaves correctly behind the proxy.
+
+**Fields**:
+- `hostHeaderMode` — preserves the original `Host`
+- `forwardedForEnabled` — emits `X-Forwarded-For`
+- `forwardedProtoEnabled` — emits `X-Forwarded-Proto`
+- `forwardedHostEnabled` — emits `X-Forwarded-Host`
+- `realIpEnabled` — emits `X-Real-IP`
+- `upgradeHeadersEnabled` — forwards `Upgrade`/`Connection` for Blazor Server interactivity
+
+**Relationships**:
+- Applied by one `Gateway Site Configuration`
+- Supports one `Upstream Application Endpoint`
+
+**Validation Rules**:
+- Must preserve enough context for secure redirects, cookies, form flows, and interactive Blazor connections.
+- Must align with the existing forwarded-header expectations in `Program.cs`.
+
+### 5. Deployment Prerequisite Set
+
+**Purpose**: The operator-supplied dependencies needed before the gateway can be activated safely.
+
+**Fields**:
+- `dnsControlAvailable` — whether `payslip4all.co.za` can resolve to the gateway host
+- `certificateMaterialAvailable` — whether HTTPS material is ready for deployment
+- `nginxRuntimeAvailable` — whether the host can install and run nginx
+- `upstreamAppAvailable` — whether Payslip4All can bind on the planned internal endpoint
+- `portAccessConfigured` — whether ports `80` and `443` are reachable as intended
+- `secretDeliveryMechanism` — how external certificate material reaches the host
+
+**Relationships**:
+- Supports one `Gateway Site Configuration`
+- Supports one `TLS Certificate Binding`
+- Supports one `Upstream Application Endpoint`
+
+**Validation Rules**:
+- DNS control and certificate availability must be confirmed before public cutover.
+- Secret delivery must stay external to source control.
+- Upstream app availability must be verifiable before nginx activation.
+
+### 6. Operator Verification Set
+
+**Purpose**: The observable checks used to confirm the gateway works after activation.
+
+**Fields**:
+- `httpsUrl` — `https://payslip4all.co.za`
+- `httpRedirectCheck` — expected redirect from HTTP to HTTPS
+- `healthCheckUrl` — public `/health` probe
+- `interactiveBlazorCheck` — evidence that WebSocket/interactive behavior still works
+- `wrongHostCheck` — expected rejection for unrelated hostnames
+- `upstreamFailureCheck` — expected unavailable response when the app is down
+
+**Relationships**:
+- Observes one `Gateway Site Configuration`
+- Observes one `Upstream Application Endpoint`
+
+**Validation Rules**:
+- Checks must map directly to FR-003 through FR-010 and SC-002 through SC-005.
+- Verification must not require undocumented deployment behavior outside the repo-owned assets.
+
+## State Model
+
+### Gateway Activation Lifecycle
+
+1. `PrerequisitesReady` — DNS, cert material, host access, and upstream inputs are available.
+2. `ConfigRendered` — nginx config and deployment-managed certificate paths are prepared on the host.
+3. `Validated` — nginx syntax/config validation and app endpoint checks pass.
+4. `Serving` — nginx serves `https://payslip4all.co.za` and proxies to the app successfully.
+5. `Degraded` — the gateway is reachable but the upstream app is unavailable, so users receive a generic unavailable response.
+6. `RotatingCertificate` — certificate material is being replaced and nginx is reloaded without changing the public host.
+
+**Transitions**:
+- `PrerequisitesReady -> ConfigRendered`: operator or bootstrap tooling places config and certificate references on the host.
+- `ConfigRendered -> Validated`: config syntax and upstream connectivity are checked successfully.
+- `Validated -> Serving`: nginx starts or reloads and serves the public domain over HTTPS.
+- `Serving -> Degraded`: the upstream app becomes unhealthy or unreachable.
+- `Degraded -> Serving`: the upstream app recovers and proxying resumes.
+- `Serving -> RotatingCertificate`: certificate material is renewed or replaced.
+- `RotatingCertificate -> Serving`: nginx reload completes and HTTPS serving continues on the same host/domain.

--- a/specs/013-nginx-https-proxy/plan.md
+++ b/specs/013-nginx-https-proxy/plan.md
@@ -1,0 +1,107 @@
+# Implementation Plan: nginx HTTPS Reverse Proxy
+
+**Branch**: `013-nginx-https-proxy` | **Date**: 2026-04-19 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `/specs/013-nginx-https-proxy/spec.md`
+
+## Summary
+
+Add a source-controlled nginx gateway definition under `infra/` that serves `payslip4all.co.za` over HTTPS, redirects HTTP to HTTPS, and reverse-proxies traffic to the existing ASP.NET Core Blazor Server app. The implementation plan assumes nginx terminates TLS on the host, forwards scheme/host/client-IP and Blazor WebSocket headers to Kestrel, restricts serving to the intended production hostname, and integrates with the repository's existing AWS CloudFormation/bootstrap/docs/test patterns instead of introducing a separate deployment stack.
+
+## Technical Context
+
+**Language/Version**: nginx configuration, Bash bootstrap scripting, and existing C# 12 / .NET 8 application runtime  
+**Primary Dependencies**: nginx, ASP.NET Core 8 reverse-proxy support, AWS CloudFormation/EC2/Secrets Manager deployment assets, Serilog request logging, xUnit + WebApplicationFactory  
+**Storage**: N/A (no application persistence or schema changes)  
+**Testing**: xUnit infrastructure/documentation tests, WebApplicationFactory reverse-proxy behavior tests, and deployment smoke checks for HTTPS redirect, `/health`, host restriction, and upstream failure handling  
+**Target Platform**: Linux server or EC2 host running nginx in front of the existing Kestrel-hosted Payslip4All app  
+**Project Type**: Infrastructure feature for an existing Blazor Server web application  
+**Performance Goals**: Preserve SC-002 through SC-005 from the spec: single-step HTTP→HTTPS redirects, first complete HTTPS page load within 5 seconds for at least 95% of smoke-test requests, and unavailable responses within 10 seconds when the upstream app is down  
+**Constraints**: `payslip4all.co.za` remains the fixed public host; TLS certificate/key material must stay external to source control; nginx must preserve forwarded scheme/host/client IP plus WebSocket upgrade headers for Blazor Server; the app must no longer be directly internet-accessible on its internal port; implementation must remain consistent with `infra/aws/cloudformation/` deployment guidance and existing .NET test conventions  
+**Scale/Scope**: One production host/domain, one nginx gateway config, one internal app endpoint (planned as `127.0.0.1:8080`), repository-owned infra/docs/tests only
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| # | Principle | Gate Question | Status |
+|---|-----------|---------------|--------|
+| I | TDD | Are failing tests planned/written before any implementation task begins? | PASS |
+| II | Clean Architecture | Does the feature touch ≤ 4 projects (Domain/Application/Infrastructure/Web)? Does each layer only depend inward? | PASS |
+| III | Blazor Web App | Are all new UI surfaces Razor components? Is business logic kept out of `.razor` files? | PASS |
+| IV | Basic Authentication | Do new pages carry `[Authorize]`? Do new service methods filter by `UserId`? | PASS |
+| V | Database Support | For EF Core providers (SQLite/MySQL): are all schema changes EF Core migrations? Is raw SQL avoided? For DynamoDB provider (`PERSISTENCE_PROVIDER=dynamodb`): do DynamoDB repositories implement all Application interfaces? Is ownership filtering enforced? | PASS |
+| VI | Manual Test Gate | Is the Manual Test Gate prompt planned at the end of each implementation task, before any `git commit`, `git merge`, or `git push`? | PASS |
+
+### Constitution Gate Notes
+
+- **Pre-research gate**: Passed because the feature is an infrastructure/runtime-edge change. No new domain rules, service interfaces, auth boundaries, or schema changes are introduced.
+- **Post-design re-check**: Passed because the design keeps changes inside existing repository boundaries: `infra/` deployment assets, `Payslip4All.Web` startup/runtime expectations if needed, and `Payslip4All.Web.Tests` validation. TDD-first implementation and the Manual Test Gate remain explicit implementation requirements.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/013-nginx-https-proxy/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── nginx-gateway-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+.
+├── infra/
+│   ├── nginx/
+│   │   ├── payslip4all.conf
+│   │   └── README.md
+│   └── aws/
+│       └── cloudformation/
+│           ├── payslip4all-web.yaml
+│           ├── README.md
+│           └── user-data/
+│               └── bootstrap-payslip4all.sh
+├── src/
+│   └── Payslip4All.Web/
+│       └── Program.cs
+└── tests/
+    └── Payslip4All.Web.Tests/
+        ├── Infrastructure/
+        │   ├── AwsDeploymentDocumentationTests.cs
+        │   └── NginxGatewayConfigTests.cs
+        ├── Integration/
+        │   └── ReverseProxyForwardingTests.cs
+        └── Startup/
+            └── AwsDeploymentStartupTests.cs
+```
+
+**Structure Decision**: Keep the new gateway assets under `infra/nginx/` as repository-owned deployment configuration, update the existing AWS CloudFormation/bootstrap/docs flow only where required to activate nginx on the current EC2-hosted path, and validate behavior through the existing `Payslip4All.Web.Tests` xUnit/WebApplicationFactory patterns.
+
+## Phase 0 Research Outcome
+
+- nginx should terminate TLS and own ports `80`/`443`, while the ASP.NET Core app moves behind it on a local-only upstream endpoint (`127.0.0.1:8080`).
+- Certificate and key material must remain externally supplied at deployment time; the plan assumes file paths under `/etc/nginx/certs/` populated from an operator-managed source such as AWS Secrets Manager or equivalent host provisioning.
+- The reverse proxy must forward `Host`, `X-Forwarded-For`, `X-Forwarded-Proto`, `X-Forwarded-Host`, and WebSocket upgrade headers so the existing Blazor Server app preserves secure redirects, cookie security, and interactive SignalR behavior.
+- nginx should enforce HTTP→HTTPS redirect before proxying, restrict serving to `payslip4all.co.za`, and provide a generic unavailable response when the upstream app is unreachable without exposing internal endpoint details.
+- Existing deployment touchpoints are `infra/aws/cloudformation/payslip4all-web.yaml`, `infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh`, `infra/aws/cloudformation/README.md`, and repository-owned .NET tests; a separate platform stack is not required.
+
+## Phase 1 Design Output
+
+- `research.md` records the implementation decisions for TLS termination, upstream porting, forwarded headers, Blazor WebSocket support, host restriction, failure handling, and AWS deployment integration.
+- `data-model.md` captures the operator-facing entities for the nginx gateway, certificate binding, upstream endpoint, header policy, prerequisites, and verification lifecycle.
+- `contracts/nginx-gateway-contract.md` defines the public gateway contract: fixed host, HTTPS behavior, redirect policy, upstream proxying, forwarded-header requirements, host filtering, and failure-response rules.
+- `quickstart.md` defines the operator-ready validation flow for prerequisites, gateway activation, HTTPS redirect verification, proxied app behavior, wrong-host rejection, upstream-failure behavior, and certificate rotation/reload checks.
+- `.github/agents/copilot-instructions.md` will be refreshed by the repository helper so future implementation agents inherit the nginx/AWS reverse-proxy planning context.
+
+## Complexity Tracking
+
+No constitutional exceptions are required for this feature.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | — | — |

--- a/specs/013-nginx-https-proxy/quickstart.md
+++ b/specs/013-nginx-https-proxy/quickstart.md
@@ -1,0 +1,65 @@
+# Quickstart: nginx HTTPS Reverse Proxy
+
+## Purpose
+
+Validate that the planned nginx gateway assets are sufficient to expose Payslip4All at `payslip4all.co.za` over HTTPS while preserving the existing ASP.NET Core reverse-proxy behavior.
+
+## Prerequisites
+
+- Control of the `payslip4all.co.za` DNS records
+- A Linux host (or EC2 instance) that can run nginx and reach the Payslip4All app
+- Deployment-managed TLS certificate and private key material for `payslip4all.co.za` (for the hosted AWS path, a secret exposing `fullchainPem` and `privkeyPem`)
+- A deployable Payslip4All app configured to bind on the planned internal endpoint (`127.0.0.1:8080`)
+- Network/security-group rules that allow inbound `80` and `443` to nginx
+- Any external secret or file-delivery mechanism required to place certificate material on the host
+
+## Scenario 1: Prepare gateway inputs
+
+1. Confirm `payslip4all.co.za` will resolve to the nginx host.
+2. Confirm the TLS certificate and key for `payslip4all.co.za` are available from the chosen deployment-managed source.
+3. Confirm the Payslip4All app can start on the planned internal endpoint instead of binding publicly on port `80`.
+4. Confirm nginx can be installed and started on the target host.
+
+## Scenario 2: Stage the gateway configuration
+
+1. Place the repository-owned nginx config from `infra/nginx/` on the target host.
+2. Place or render the certificate and key into the expected runtime location (for example `/etc/nginx/certs/` with `fullchain.pem` and `privkey.pem`).
+3. Configure the app environment so nginx owns ports `80` and `443`, while the app listens on the planned internal endpoint.
+4. Validate the nginx configuration with `nginx -t` before reload/start.
+
+## Scenario 3: Verify secure public access
+
+1. Browse to `https://payslip4all.co.za`.
+2. Confirm the browser reaches Payslip4All successfully over HTTPS.
+3. Browse to `http://payslip4all.co.za`.
+4. Confirm the request redirects to the equivalent HTTPS URL in a single navigation step.
+
+## Scenario 4: Verify proxied app behavior
+
+1. Open the public site and complete an interactive navigation flow through the nginx host.
+2. Confirm the app still behaves as a Blazor Server application behind the proxy.
+3. Confirm `/health` returns a healthy response through `https://payslip4all.co.za/health`.
+4. Confirm generated redirects, secure cookies, and normal form submissions continue to use the public HTTPS host.
+
+## Scenario 5: Verify host restriction
+
+1. Send a request to the gateway host using a hostname other than `payslip4all.co.za`.
+2. Confirm the gateway does not serve the production app for that unrelated hostname.
+3. Confirm the rejection path does not disclose the internal app endpoint.
+
+## Scenario 6: Verify upstream failure handling
+
+1. Stop or make the internal Payslip4All endpoint unavailable.
+2. Request `https://payslip4all.co.za`.
+3. Confirm users receive an unavailable response within 10 seconds.
+4. Confirm the response does not reveal `127.0.0.1:8080` or other internal network details.
+
+## Scenario 7: Verify certificate replacement workflow
+
+1. Replace or rotate the deployment-managed certificate material without changing the public domain.
+2. Re-run `nginx -t` and reload nginx using the documented operator workflow.
+3. Confirm `https://payslip4all.co.za` still serves successfully with the renewed certificate.
+
+## Validation Outcome
+
+The feature is ready for implementation when the planned assets and instructions support all seven scenarios above without requiring undocumented host-specific steps outside the repository-owned deployment flow.

--- a/specs/013-nginx-https-proxy/research.md
+++ b/specs/013-nginx-https-proxy/research.md
@@ -1,0 +1,57 @@
+# Research: nginx HTTPS Reverse Proxy
+
+## Decision 1: Terminate TLS at nginx and externalize certificate material
+
+- **Decision**: Terminate HTTPS at nginx and load the certificate/key from deployment-managed files such as `/etc/nginx/certs/fullchain.pem` and `/etc/nginx/certs/privkey.pem`, with the file contents populated from an external secret source rather than committed to the repo.
+- **Rationale**: The feature requires a source-controlled gateway definition without embedding secrets. The existing app already honors forwarded headers and `UseHttpsRedirection()`, so nginx can own TLS while the app stays on internal HTTP. This also keeps certificate rotation operationally separate from the application binary.
+- **Alternatives considered**:
+  - **Terminate TLS inside ASP.NET Core only**: Rejected because it weakens the purpose of the nginx gateway and keeps certificates coupled to the app process.
+  - **Use a new ALB/ACM-only design instead of nginx**: Rejected because the requested feature is specifically an nginx configuration under `infra/`.
+
+## Decision 2: Move the app behind nginx on a local-only upstream endpoint
+
+- **Decision**: Plan the upstream Payslip4All app to bind to `http://127.0.0.1:8080`, leaving nginx to own public ports `80` and `443`.
+- **Rationale**: This keeps nginx as the only public entry point, aligns with FR-005/FR-010, and reduces accidental exposure of the app's internal endpoint. It fits the current single-host deployment model described in `infra/aws/cloudformation/`.
+- **Alternatives considered**:
+  - **Keep the app on `0.0.0.0:80` and place nginx on another host**: Rejected because it expands the scope beyond the current EC2-hosted deployment path.
+  - **Use a Unix domain socket immediately**: Rejected because it adds bootstrap and permissions complexity without clear value for the current single-instance plan.
+
+## Decision 3: Preserve forwarded headers and Blazor WebSocket upgrade headers
+
+- **Decision**: Require nginx to forward `Host`, `X-Forwarded-For`, `X-Forwarded-Proto`, `X-Forwarded-Host`, `X-Real-IP`, `Upgrade`, and `Connection` headers when proxying to the app.
+- **Rationale**: `Program.cs` already configures forwarded-header handling and `UseHttpsRedirection()`, and Blazor Server requires WebSocket/SignalR upgrade support for interactive pages. Preserving scheme and host is also necessary for secure cookies, absolute redirects, and provider callback URLs.
+- **Alternatives considered**:
+  - **Forward only `X-Forwarded-For` and `X-Forwarded-Proto`**: Rejected because host-sensitive behaviors and WebSocket upgrades would remain under-specified.
+  - **Add application-side custom header translation**: Rejected because the repo already follows standard ASP.NET Core reverse-proxy patterns.
+
+## Decision 4: Enforce HTTP→HTTPS redirect and strict host filtering at nginx
+
+- **Decision**: Use a dedicated HTTP server block that redirects requests for `payslip4all.co.za` to the equivalent HTTPS URL, and include a catch-all/default behavior that does not serve unrelated hostnames as the production site.
+- **Rationale**: Redirecting at nginx is simpler and more efficient than letting insecure requests reach the app. Host filtering directly supports FR-010 and reduces host-header confusion or accidental production aliasing.
+- **Alternatives considered**:
+  - **Let ASP.NET Core perform all redirects and host handling**: Rejected because the public gateway should own protocol and hostname enforcement.
+  - **Accept arbitrary hosts and rely on DNS alone**: Rejected because the spec explicitly requires restricting application serving to the intended public host.
+
+## Decision 5: Return generic unavailable responses when the upstream app is down
+
+- **Decision**: Configure nginx timeouts and upstream error handling so failed upstream requests become a generic `503 Service Unavailable` style response without exposing the internal address or port.
+- **Rationale**: FR-007 requires a non-success response that hides internal network details. A gateway-controlled fallback page or error mapping keeps failures user-safe and operator-debuggable.
+- **Alternatives considered**:
+  - **Expose nginx default `502 Bad Gateway` output unchanged**: Rejected because default error pages can reveal too much about the gateway or upstream topology.
+  - **Retry aggressively for long periods**: Rejected because SC-005 requires an unavailable response within 10 seconds.
+
+## Decision 6: Treat `infra/nginx/` as the primary artifact and update the existing AWS path only as needed
+
+- **Decision**: Place the gateway config and its operator guidance under `infra/nginx/`, then update `infra/aws/cloudformation/payslip4all-web.yaml`, `infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh`, and `infra/aws/cloudformation/README.md` only where needed to install/configure nginx on the current hosted-AWS path.
+- **Rationale**: The repo already keeps deployable infrastructure assets and operator docs under `infra/aws/cloudformation/`, so the nginx feature should extend that flow instead of inventing a second deployment story.
+- **Alternatives considered**:
+  - **Create a brand-new AWS deployment stack just for nginx**: Rejected because it duplicates existing deployment ownership.
+  - **Keep the config outside `infra/` and document it only in README**: Rejected because FR-001 and FR-009 require a source-controlled infra artifact with activation guidance.
+
+## Decision 7: Validate the feature through existing .NET test patterns plus operator smoke checks
+
+- **Decision**: Plan failing tests first in `Payslip4All.Web.Tests` for nginx config/documentation expectations and reverse-proxy-aware application behavior, then use deployment smoke checks to verify HTTPS, redirect, `/health`, wrong-host handling, and upstream failure behavior.
+- **Rationale**: The constitution requires TDD, and the repo already validates infrastructure and deployment docs through xUnit/WebApplicationFactory tests. Reusing those patterns avoids adding a new test stack during planning.
+- **Alternatives considered**:
+  - **Rely on manual nginx testing only**: Rejected because it violates Principle I (TDD).
+  - **Introduce a dedicated infrastructure test framework now**: Rejected because the repo already has established .NET-based validation patterns.

--- a/specs/013-nginx-https-proxy/spec.md
+++ b/specs/013-nginx-https-proxy/spec.md
@@ -1,0 +1,106 @@
+# Feature Specification: Secure Public Gateway Configuration
+
+**Feature Branch**: `013-nginx-https-proxy`  
+**Created**: 2026-04-19  
+**Status**: Draft  
+**Input**: User description: "In the infra folder, create an nginx config for the payslip application. Use the domain payslip4all.co.za, configure the application for HTTPS and ensure that nginx is configured as a reverse proxy."
+
+## Architecture & TDD Alignment *(mandatory for Payslip4All)*
+
+- **Domain**: No payroll rules, calculations, or legal document content change in this feature.
+- **Application**: Existing application use cases remain unchanged; the feature only affects how the running application is exposed publicly.
+- **Infrastructure**: This feature adds a source-controlled public gateway configuration in `infra/` that defines domain routing, secure access, reverse proxy behaviour, and deployment prerequisites.
+- **Web**: The web application must behave correctly when requests arrive through the secure public host rather than a directly exposed application endpoint.
+- **TDD Alignment**: Each requirement is written as observable deployment behaviour so failing configuration validation checks, redirect tests, and reverse-proxy smoke tests can be created before implementation.
+
+### User Story 1 - Serve the public site securely (Priority: P1)
+
+As an operator, I want Payslip4All to be reachable at payslip4all.co.za over a secure connection so end users can access the live application through a trusted public address.
+
+**Why this priority**: Secure public access is the minimum value of this feature. Without it, the deployment cannot safely expose the application to real users.
+
+**Independent Test**: Apply the provided gateway configuration in a deployment environment with the required domain and certificate prerequisites, then verify secure requests succeed and non-secure requests redirect.
+
+**Acceptance Scenarios**:
+
+1. **Given** the required domain and secure-connection prerequisites are available, **When** a user browses to `https://payslip4all.co.za`, **Then** the application responds successfully from that public address over a secure connection.
+2. **Given** a user attempts to access `http://payslip4all.co.za`, **When** the request reaches the public gateway, **Then** the user is redirected to the equivalent secure URL before interacting with the application.
+
+---
+
+### User Story 2 - Route public traffic to the running application (Priority: P2)
+
+As an operator, I want the public gateway to forward incoming requests to the running Payslip4All service so the application can stay behind one controlled public entry point.
+
+**Why this priority**: Reverse proxy routing is required for the secure public address to be useful. Without correct forwarding, the domain exists but the application does not function for end users.
+
+**Independent Test**: Start the application on its intended internal endpoint, send representative page and form requests through payslip4all.co.za, and confirm the application completes them without exposing the internal endpoint directly.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Payslip4All application is running on its configured internal endpoint, **When** a user requests a page through `https://payslip4all.co.za`, **Then** the gateway forwards the request and returns the application response from the public domain.
+2. **Given** a user completes a normal interaction such as sign-in or form submission through the public domain, **When** the request passes through the gateway, **Then** the application receives enough original request context to preserve secure links, redirects, and submitted data correctly.
+3. **Given** the internal application endpoint is unavailable, **When** a user requests the public domain, **Then** the gateway returns an unavailable response and does not reveal internal endpoint details.
+
+---
+
+### User Story 3 - Maintain a reusable deployment gateway definition (Priority: P3)
+
+As an operator, I want the public gateway definition stored in the repository's infra folder with clear activation prerequisites so it can be reviewed, versioned, and reused in deployment workflows.
+
+**Why this priority**: A reusable, source-controlled infrastructure artifact reduces setup drift and makes future deployment changes auditable, but it depends on the secure routing behaviour delivered by the higher-priority stories.
+
+**Independent Test**: Inspect the repository, locate the gateway artifact in `infra/`, and verify an operator can identify the required public domain, secure-connection inputs, and upstream application inputs without reverse-engineering the file.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator has a repository checkout, **When** they inspect the `infra/` folder, **Then** they can locate the public gateway configuration artifact for the Payslip4All deployment.
+2. **Given** environment-specific upstream or secure-connection values must change, **When** the operator updates the documented deployment inputs, **Then** the public domain and routing behaviour remain consistent without redefining the overall gateway behaviour.
+
+---
+
+### Edge Cases
+
+- What happens when `payslip4all.co.za` points to the public gateway before the secure-connection materials are ready for use?
+- How does the public gateway respond when the upstream Payslip4All application is stopped, unreachable, or slow to respond?
+- What happens when a request arrives with a hostname other than `payslip4all.co.za`?
+- How is secure access preserved when certificate or key material is renewed or replaced without changing the public domain?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The feature MUST provide a source-controlled public gateway configuration artifact in the `infra/` folder for the Payslip4All deployment.
+- **FR-002**: The public gateway configuration MUST treat `payslip4all.co.za` as the primary public host for this feature.
+- **FR-003**: The public gateway MUST accept secure requests for `payslip4all.co.za` and deliver the application through that secure endpoint.
+- **FR-004**: The public gateway MUST redirect non-secure requests for `payslip4all.co.za` to the equivalent secure URL.
+- **FR-005**: The public gateway MUST forward end-user requests from `payslip4all.co.za` to a configured internal Payslip4All application endpoint without requiring end users to know or access that internal endpoint directly.
+- **FR-006**: Forwarded requests MUST preserve the original request context needed for the application to recognize the public host and secure scheme during normal page loads, redirects, and form submissions.
+- **FR-007**: When the internal application endpoint is unavailable, the public gateway MUST return a non-success response and MUST NOT expose internal network details in the user-facing response.
+- **FR-008**: Environment-specific activation values, including secure-connection material references and the upstream application address, MUST be externally configurable rather than hardcoded, except for the required public domain in this feature.
+- **FR-009**: The feature MUST document the operator prerequisites and activation inputs needed to use the public gateway configuration safely in a deployment environment.
+- **FR-010**: The public gateway configuration MUST restrict application serving to the intended public host so unrelated hostnames are not treated as the production entry point.
+
+### Key Entities *(include if feature involves data)*
+
+- **Public Gateway Configuration**: The source-controlled deployment artifact that defines the public host, secure-access behaviour, and request forwarding rules for Payslip4All.
+- **Secure Access Policy**: The set of rules that determine how secure and non-secure requests are handled for `payslip4all.co.za`.
+- **Upstream Application Endpoint**: The internal Payslip4All destination that receives forwarded traffic from the public gateway.
+- **Deployment Prerequisite Set**: The operator-supplied domain, secure-connection, and upstream values required to activate the configuration in an environment.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An operator can locate the public gateway artifact and identify its required activation inputs within 5 minutes of opening the repository.
+- **SC-002**: In smoke testing, 100% of requests sent to `http://payslip4all.co.za` are redirected to `https://payslip4all.co.za` in a single navigation step.
+- **SC-003**: During a standard smoke test, users can load the first complete application page through `https://payslip4all.co.za` within 5 seconds for at least 95% of requests.
+- **SC-004**: In representative smoke testing, 100% of public-domain interactions covering initial page load, authenticated navigation, and form submission complete successfully without direct access to the internal application endpoint.
+- **SC-005**: When the upstream application is unavailable, users receive an unavailable response from the public domain within 10 seconds and no internal endpoint details are shown.
+
+## Assumptions
+
+- Control of the `payslip4all.co.za` DNS records is already available before this feature is activated.
+- Secure-connection materials can be supplied by the deployment environment and are managed separately from application source code.
+- A single public host is sufficient for this feature; additional aliases or subdomains are out of scope unless requested later.
+- The Payslip4All application already has a reachable internal address or port that can be provided as an environment-specific deployment input.

--- a/specs/013-nginx-https-proxy/tasks.md
+++ b/specs/013-nginx-https-proxy/tasks.md
@@ -1,0 +1,209 @@
+# Tasks: nginx HTTPS Reverse Proxy
+
+**Input**: Design documents from `/specs/013-nginx-https-proxy/`  
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, quickstart.md, contracts/nginx-gateway-contract.md
+
+**Tests**: Per constitution Principle I (TDD), tests are **REQUIRED** for this feature. Write the failing xUnit/WebApplicationFactory tests first, confirm they fail, then implement the minimum change to pass.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and validated independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no unmet dependencies)
+- **[Story]**: User story label (`[US1]`, `[US2]`, `[US3]`)
+- Every task includes the exact file path(s) to change or validate
+
+## Path Conventions
+
+- Web app startup: `src/Payslip4All.Web/Program.cs`
+- AWS deployment assets: `infra/aws/cloudformation/payslip4all-web.yaml`, `infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh`, `infra/aws/cloudformation/README.md`
+- New nginx assets: `infra/nginx/`
+- Web deployment tests: `tests/Payslip4All.Web.Tests/{Infrastructure,Integration,Startup}`
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the source-controlled nginx artifact locations and matching test files before feature implementation starts.
+
+- [X] T001 Create the nginx asset structure in infra/nginx/README.md and infra/nginx/payslip4all.conf
+- [X] T002 Create gateway test files in tests/Payslip4All.Web.Tests/Infrastructure/NginxGatewayConfigTests.cs and tests/Payslip4All.Web.Tests/Integration/ReverseProxyForwardingTests.cs
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the shared runtime assumptions that every user story depends on.
+
+**⚠️ CRITICAL**: Complete this phase before any user story implementation starts.
+
+- [X] T003 [P] Update nginx-hosted startup expectations in tests/Payslip4All.Web.Tests/Startup/AwsDeploymentStartupTests.cs
+- [X] T004 [P] Replace CloudFormation baseline assertions with nginx port, certificate, and bootstrap checks in tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs
+- [X] T005 [P] Implement nginx runtime prerequisites, certificate directories, and ASPNETCORE_URLS=http://127.0.0.1:8080 in infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh
+- [X] T006 [P] Mirror the nginx-hosted baseline network, certificate inputs, and bootstrap wiring in infra/aws/cloudformation/payslip4all-web.yaml
+
+**Checkpoint**: nginx is the planned public edge and the app is prepared to run only on `127.0.0.1:8080`.
+
+---
+
+## Phase 3: User Story 1 - Serve the public site securely (Priority: P1) 🎯 MVP
+
+**Goal**: Expose `payslip4all.co.za` over HTTPS and redirect HTTP requests to the secure URL.
+
+**Independent Test**: Apply the repository-owned gateway configuration, request `https://payslip4all.co.za`, and confirm HTTPS succeeds while `http://payslip4all.co.za` redirects once to the equivalent HTTPS URL.
+
+### Tests for User Story 1 (REQUIRED — TDD, constitution Principle I)
+
+> **MANDATORY: Write these tests FIRST, confirm they FAIL, then begin implementation**
+
+- [X] T007 [P] [US1] Add nginx config tests for payslip4all.co.za HTTPS serving, TLS file references, and HTTP→HTTPS redirect in tests/Payslip4All.Web.Tests/Infrastructure/NginxGatewayConfigTests.cs
+
+### Implementation for User Story 1
+
+- [X] T008 [US1] Implement the payslip4all.co.za HTTP redirect server block and HTTPS listener in infra/nginx/payslip4all.conf
+- [X] T009 [US1] Document TLS file references, domain prerequisites, and HTTPS activation steps in infra/nginx/README.md
+- [X] T010 [P] [US1] Update HTTPS smoke-test and public-entrypoint guidance in infra/aws/cloudformation/README.md
+
+**Checkpoint**: User Story 1 is complete when the gateway serves the production host only over HTTPS and all secure-access tests pass.
+
+---
+
+## Phase 4: User Story 2 - Route public traffic to the running application (Priority: P2)
+
+**Goal**: Reverse-proxy public traffic to the internal Payslip4All app while preserving forwarded request context and Blazor Server interactivity.
+
+**Independent Test**: Start the app on `127.0.0.1:8080`, send representative requests through the public gateway, and confirm `/health`, redirects, form flows, and upstream failure handling work without exposing the internal endpoint.
+
+### Tests for User Story 2 (REQUIRED — TDD, constitution Principle I)
+
+- [X] T011 [P] [US2] Add reverse-proxy integration tests for forwarded scheme/host, public /health, and generic upstream failure behavior in tests/Payslip4All.Web.Tests/Integration/ReverseProxyForwardingTests.cs
+- [X] T012 [P] [US2] Extend startup tests for X-Forwarded-Host processing and local-only upstream hosting in tests/Payslip4All.Web.Tests/Startup/AwsDeploymentStartupTests.cs
+
+### Implementation for User Story 2
+
+- [X] T013 [US2] Update forwarded-header middleware for proxy-safe redirects and forwarded host support in src/Payslip4All.Web/Program.cs
+- [X] T014 [US2] Add proxy_pass, forwarded headers, WebSocket upgrade handling, /health proxying, host filtering, and generic 503 fallback rules in infra/nginx/payslip4all.conf
+- [X] T015 [US2] Update nginx activation, config validation, and service restart order for the 127.0.0.1:8080 upstream in infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh
+
+**Checkpoint**: User Story 2 is complete when proxied requests behave like first-class public HTTPS requests and upstream outages return a safe failure response.
+
+---
+
+## Phase 5: User Story 3 - Maintain a reusable deployment gateway definition (Priority: P3)
+
+**Goal**: Keep the nginx gateway artifact discoverable, documented, and aligned with the repository’s AWS deployment workflow.
+
+**Independent Test**: Inspect the repo and confirm an operator can find the nginx artifact in `infra/`, identify its required certificate/upstream inputs, and follow the AWS/bootstrap guidance without any ALB/Route53/ACM assumptions.
+
+### Tests for User Story 3 (REQUIRED — TDD, constitution Principle I)
+
+- [X] T016 [P] [US3] Rewrite deployment documentation expectations for nginx, Elastic IP, certificate staging, and no-ALB/no-Route53/no-ACM assumptions in tests/Payslip4All.Web.Tests/Infrastructure/AwsDeploymentDocumentationTests.cs
+- [X] T017 [P] [US3] Add discoverability and operator-input assertions for infra/nginx/README.md and infra/nginx/payslip4all.conf in tests/Payslip4All.Web.Tests/Infrastructure/NginxGatewayConfigTests.cs
+
+### Implementation for User Story 3
+
+- [X] T018 [US3] Expand reusable gateway inputs, certificate reload steps, wrong-host validation, and operator checks in infra/nginx/README.md
+- [X] T019 [P] [US3] Update the AWS operator runbook for nginx bootstrap, certificate delivery, HTTPS smoke tests, and Elastic-IP publishing in infra/aws/cloudformation/README.md
+- [X] T020 [P] [US3] Replace ALB-based deployment guidance with nginx-based deployment guidance in ./README.md
+
+**Checkpoint**: User Story 3 is complete when operators can discover the gateway artifact quickly and the documentation/tests consistently describe the nginx-based deployment path.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation and cross-story cleanup after the three user stories are complete.
+
+- [X] T021 [P] Align the feature smoke-check wording with the implemented gateway workflow in specs/013-nginx-https-proxy/quickstart.md
+- [X] T022 Run the gateway-focused regression suite from tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj
+- [X] T023 Execute the operator validation checklist from specs/013-nginx-https-proxy/quickstart.md against infra/nginx/README.md and infra/aws/cloudformation/README.md
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1: Setup** — no dependencies
+- **Phase 2: Foundational** — depends on Phase 1 and blocks all story work
+- **Phase 3: US1** — depends on Phase 2; this is the MVP
+- **Phase 4: US2** — depends on Phase 2 and should follow US1 because both stories modify infra/nginx/payslip4all.conf and the hosted AWS runtime path
+- **Phase 5: US3** — depends on US1 and US2 so the documentation matches the final nginx behavior
+- **Phase 6: Polish** — depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Starts after Foundational; no dependency on other user stories
+- **US2 (P2)**: Starts after Foundational, but sequence it after US1 to avoid conflicts in infra/nginx/payslip4all.conf and infra/aws/cloudformation/user-data/bootstrap-payslip4all.sh
+- **US3 (P3)**: Starts after US1 and US2 so tests/docs describe the final gateway implementation rather than interim behavior
+
+### Within Each User Story
+
+- Write the listed tests first and confirm they fail before implementation
+- Update shared infra/test files in the order listed to minimize merge conflicts
+- Re-run the relevant xUnit/WebApplicationFactory coverage after each story reaches green
+- **Manual Test Gate (Principle VI)**: After each implementation task, present the manual test gate prompt and wait for explicit engineer approval before any `git commit`, `git merge`, or `git push`
+
+---
+
+## Parallel Opportunities
+
+- **Foundational**: T003 and T004 can run in parallel first, then T005 and T006 can run in parallel once those tests fail
+- **US1**: T009 and T010 can run in parallel after T008 establishes the HTTPS listener behavior
+- **US2**: T011 and T012 can run in parallel before implementation
+- **US3**: T016 and T017 can run in parallel first, then T019 and T020 can run in parallel after T018 defines the reusable gateway guidance
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "Document TLS file references, domain prerequisites, and HTTPS activation steps in infra/nginx/README.md"
+Task: "Update HTTPS smoke-test and public-entrypoint guidance in infra/aws/cloudformation/README.md"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+Task: "Add reverse-proxy integration tests for forwarded scheme/host, public /health, and generic upstream failure behavior in tests/Payslip4All.Web.Tests/Integration/ReverseProxyForwardingTests.cs"
+Task: "Extend startup tests for X-Forwarded-Host processing and local-only upstream hosting in tests/Payslip4All.Web.Tests/Startup/AwsDeploymentStartupTests.cs"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+Task: "Rewrite deployment documentation expectations for nginx, Elastic IP, certificate staging, and no-ALB/no-Route53/no-ACM assumptions in tests/Payslip4All.Web.Tests/Infrastructure/AwsDeploymentDocumentationTests.cs"
+Task: "Add discoverability and operator-input assertions for infra/nginx/README.md and infra/nginx/payslip4all.conf in tests/Payslip4All.Web.Tests/Infrastructure/NginxGatewayConfigTests.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Run the US1 tests and perform the HTTPS + redirect smoke checks from specs/013-nginx-https-proxy/quickstart.md
+5. Present the Manual Test Gate prompt and wait for approval before any git operation
+
+### Incremental Delivery
+
+1. Finish Setup + Foundational so nginx becomes the planned public edge
+2. Deliver **US1** for HTTPS publishing and redirect behavior
+3. Deliver **US2** for reverse-proxy forwarding, Blazor WebSocket support, and safe outage handling
+4. Deliver **US3** for reusable operator documentation and updated AWS deployment guidance
+5. Finish with Polish tasks to verify the docs, tests, and quickstart all match
+
+### Suggested Team Strategy
+
+1. One engineer completes Phases 1-2 because they change the shared deployment baseline
+2. After that, one engineer can drive **US1/US2** on the nginx/runtime path while another prepares **US3** test/doc rewrites once the nginx behavior is settled
+3. Rejoin for Phase 6 to run the full gateway regression suite and operator checklist
+
+---
+
+## Notes
+
+- All checklist items use the required `- [ ] T### [P?] [Story?] Description with file path` format
+- The outdated ALB/Route53/ACM expectations are intentionally replaced by nginx/Elastic-IP/bootstrap expectations in the AWS test and documentation tasks above
+- Keep certificate material external to source control; only file paths, references, and operator steps belong in tracked files
+- `infra/nginx/payslip4all.conf` is a shared hotspot across US1-US3, so complete tasks in order to avoid churn
+- Do not commit or merge until the Manual Test Gate is explicitly approved

--- a/src/Payslip4All.Web/Program.cs
+++ b/src/Payslip4All.Web/Program.cs
@@ -32,7 +32,10 @@ builder.Host.UseSerilog((ctx, lc) =>
 // Must be registered before the middleware pipeline is built.
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
-    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    options.ForwardedHeaders =
+        ForwardedHeaders.XForwardedFor |
+        ForwardedHeaders.XForwardedProto |
+        ForwardedHeaders.XForwardedHost;
     // Trust any proxy IP — restrict to specific KnownProxies entries in production.
     options.KnownNetworks.Clear();
     options.KnownProxies.Clear();

--- a/tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs
+++ b/tests/Payslip4All.Web.Tests/Infrastructure/AwsCloudFormationTemplateTests.cs
@@ -1,28 +1,20 @@
-using System.Text.RegularExpressions;
-using YamlDotNet.RepresentationModel;
-
 namespace Payslip4All.Web.Tests.Infrastructure;
 
 public class AwsCloudFormationTemplateTests
 {
     [Fact]
-    public void Template_DeclaresRequiredParameters_And_DynamoDbDefaults()
+    public void Template_DeclaresRequiredParameters_And_NginxCertificateInputs()
     {
         var template = LoadTemplate();
 
         Assert.Contains("Parameters:", template, StringComparison.Ordinal);
         Assert.Contains("EnvironmentName:", template, StringComparison.Ordinal);
-        Assert.Contains("DomainName:", template, StringComparison.Ordinal);
-        Assert.Contains("HostedZoneId:", template, StringComparison.Ordinal);
-        Assert.Contains("CertificateArn:", template, StringComparison.Ordinal);
         Assert.Contains("InstanceType:", template, StringComparison.Ordinal);
         Assert.Contains("ArtifactSource:", template, StringComparison.Ordinal);
-        Assert.Contains("AllowedSshCidr:", template, StringComparison.Ordinal);
-        Assert.Contains("DynamoDbRegion:", template, StringComparison.Ordinal);
         Assert.Contains("DynamoDbTablePrefix:", template, StringComparison.Ordinal);
         Assert.Contains("HostedPaymentsSecretArn:", template, StringComparison.Ordinal);
-        Assert.Contains("EnablePointInTimeRecovery:", template, StringComparison.Ordinal);
-        Assert.Contains("Default: 'true'", template, StringComparison.Ordinal);
+        Assert.Contains("TlsCertificateSecretArn:", template, StringComparison.Ordinal);
+        Assert.Contains("payslip4all.co.za", template, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -33,10 +25,12 @@ public class AwsCloudFormationTemplateTests
         Assert.Contains("Outputs:", template, StringComparison.Ordinal);
         Assert.Contains("ApplicationUrl:", template, StringComparison.Ordinal);
         Assert.Contains("InstanceId:", template, StringComparison.Ordinal);
-        Assert.Contains("LoadBalancerArn:", template, StringComparison.Ordinal);
+        Assert.Contains("ElasticIpAddress:", template, StringComparison.Ordinal);
         Assert.Contains("InstanceSecurityGroupId:", template, StringComparison.Ordinal);
-        Assert.Contains("LoadBalancerSecurityGroupId:", template, StringComparison.Ordinal);
+        Assert.Contains("SsmStartSessionCommand:", template, StringComparison.Ordinal);
         Assert.Contains("HostedPaymentsSecretReference:", template, StringComparison.Ordinal);
+        Assert.Contains("TlsCertificateSecretReference:", template, StringComparison.Ordinal);
+        Assert.Contains("NginxConfigPath:", template, StringComparison.Ordinal);
         Assert.Contains("BackupProtectionMode:", template, StringComparison.Ordinal);
         Assert.Contains("RestoreRunbook:", template, StringComparison.Ordinal);
     }
@@ -46,78 +40,39 @@ public class AwsCloudFormationTemplateTests
     {
         var template = LoadTemplate();
 
-        Assert.Contains("AWS::EC2::VPC", template, StringComparison.Ordinal);
-        Assert.Contains("AWS::EC2::Subnet", template, StringComparison.Ordinal);
-        Assert.Contains("AWS::EC2::InternetGateway", template, StringComparison.Ordinal);
-        Assert.Contains("AWS::EC2::RouteTable", template, StringComparison.Ordinal);
         Assert.Contains("AWS::EC2::SecurityGroup", template, StringComparison.Ordinal);
         Assert.Contains("AWS::EC2::Instance", template, StringComparison.Ordinal);
+        Assert.Contains("AWS::EC2::EIP", template, StringComparison.Ordinal);
         Assert.Contains("AWS::IAM::Role", template, StringComparison.Ordinal);
         Assert.Contains("AWS::IAM::InstanceProfile", template, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void Template_PlacesTheApplicationBehindAnAlb_WithHealthBasedRouting()
+    public void Template_ExposesOnlyNginxPublicPorts_And_KeepsTheAppPortPrivate()
     {
         var template = LoadTemplate();
 
-        Assert.Contains("AWS::ElasticLoadBalancingV2::LoadBalancer", template, StringComparison.Ordinal);
-        Assert.Contains("AWS::ElasticLoadBalancingV2::TargetGroup", template, StringComparison.Ordinal);
-        Assert.Contains("AWS::ElasticLoadBalancingV2::TargetGroupAttachment", template, StringComparison.Ordinal);
-        Assert.Contains("AWS::ElasticLoadBalancingV2::Listener", template, StringComparison.Ordinal);
-        Assert.Contains("HealthCheckPath: /health", template, StringComparison.Ordinal);
-        Assert.Contains("TargetId: !Ref WebInstance", template, StringComparison.Ordinal);
+        Assert.Contains("FromPort: 80", template, StringComparison.Ordinal);
+        Assert.Contains("ToPort: 80", template, StringComparison.Ordinal);
+        Assert.Contains("FromPort: 443", template, StringComparison.Ordinal);
+        Assert.Contains("ToPort: 443", template, StringComparison.Ordinal);
+        Assert.DoesNotContain("FromPort: 8080", template, StringComparison.Ordinal);
+        Assert.DoesNotContain("ToPort: 8080", template, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void Template_UsesAllowedSshCidr_WithoutHardcodedOperatorAccess()
+    public void Template_UsesSecretsBackedCertificateBootstrap_And_NginxUserDataWiring()
     {
         var template = LoadTemplate();
 
-        Assert.Matches(@"AllowedSshCidr:\s*\n\s*Type:\s*String", template);
-        Assert.Matches(@"FromPort:\s*22\s*\n\s*ToPort:\s*22\s*\n\s*CidrIp:\s*!Ref AllowedSshCidr", template);
-        Assert.DoesNotContain("FromPort: 22\n          ToPort: 22\n          CidrIp: 0.0.0.0/0", template, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public void Template_KeepsSharedInfrastructure_IndependentOfEc2Replacement()
-    {
-        var resources = LoadResources();
-
-        Assert.False(ResourceReferencesNode(resources, "ApplicationLoadBalancer", "WebInstance"));
-        Assert.False(ResourceReferencesNode(resources, "ApplicationTargetGroup", "WebInstance"));
-        Assert.False(ResourceReferencesNode(resources, "PublicDnsRecord", "WebInstance"));
-        Assert.False(ResourceReferencesNode(resources, "PublicVpc", "WebInstance"));
-        Assert.True(ResourceReferencesNode(resources, "WebInstanceTargetAttachment", "WebInstance"));
-    }
-
-    [Fact]
-    public void Template_ImplementsHttpsPublishing_And_HealthAwareDnsRouting()
-    {
-        var template = LoadTemplate();
-
-        Assert.Contains("RedirectConfig", template, StringComparison.Ordinal);
-        Assert.Contains("CertificateArn: !Ref CertificateArn", template, StringComparison.Ordinal);
-        Assert.Contains("SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06", template, StringComparison.Ordinal);
-        Assert.Contains("AWS::Route53::RecordSet", template, StringComparison.Ordinal);
-        Assert.Contains("EvaluateTargetHealth: true", template, StringComparison.Ordinal);
-        Assert.Contains("payslip4all-co-za-web-${EnvironmentName}", template, StringComparison.Ordinal);
-        Assert.Contains("payslip4all-co-za-alb-${EnvironmentName}", template, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public void Template_WaitsForBootstrapHealth_And_SecuresEnvironmentFileBeforeWritingSecrets()
-    {
-        var template = LoadTemplate();
-
-        Assert.Contains("CreationPolicy:", template, StringComparison.Ordinal);
-        Assert.Contains("ResourceSignal:", template, StringComparison.Ordinal);
-        Assert.Contains("Timeout: PT15M", template, StringComparison.Ordinal);
-        Assert.Contains("install -m 0600 /dev/null \"${ENV_FILE}\"", template, StringComparison.Ordinal);
-        Assert.Contains("chmod 600 \"${ENV_FILE}\"", template, StringComparison.Ordinal);
-        Assert.Contains("aws cloudformation signal-resource", template, StringComparison.Ordinal);
-        Assert.Contains("systemctl is-active --quiet payslip4all.service", template, StringComparison.Ordinal);
-        Assert.Contains("http://127.0.0.1/health", template, StringComparison.Ordinal);
+        Assert.Contains("secretsmanager:GetSecretValue", template, StringComparison.Ordinal);
+        Assert.Contains("/etc/nginx/certs/fullchain.pem", template, StringComparison.Ordinal);
+        Assert.Contains("/etc/nginx/certs/privkey.pem", template, StringComparison.Ordinal);
+        Assert.Contains("/etc/nginx/conf.d/payslip4all.conf", template, StringComparison.Ordinal);
+        Assert.Contains("ASPNETCORE_URLS=http://127.0.0.1:8080", template, StringComparison.Ordinal);
+        Assert.Contains("nginx -t", template, StringComparison.Ordinal);
+        Assert.Contains("systemctl restart nginx", template, StringComparison.Ordinal);
+        Assert.Contains("systemctl restart payslip4all.service", template, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -135,55 +90,6 @@ public class AwsCloudFormationTemplateTests
     private static string LoadTemplate()
     {
         return File.ReadAllText(Path.Combine(GetSolutionRoot(), "infra", "aws", "cloudformation", "payslip4all-web.yaml"));
-    }
-
-    private static YamlMappingNode LoadResources()
-    {
-        using var reader = new StringReader(LoadTemplate());
-        var stream = new YamlStream();
-        stream.Load(reader);
-
-        var root = (YamlMappingNode)stream.Documents[0].RootNode;
-        return (YamlMappingNode)root.Children[new YamlScalarNode("Resources")];
-    }
-
-    private static bool ResourceReferencesNode(YamlMappingNode resources, string resourceName, string targetName)
-    {
-        var resource = (YamlMappingNode)resources.Children[new YamlScalarNode(resourceName)];
-        return NodeContainsReference(resource, targetName);
-    }
-
-    private static bool NodeContainsReference(YamlNode node, string targetName)
-    {
-        switch (node)
-        {
-            case YamlScalarNode scalar:
-                return string.Equals(scalar.Value, targetName, StringComparison.Ordinal);
-
-            case YamlSequenceNode sequence:
-                return sequence.Children.Any(child => NodeContainsReference(child, targetName));
-
-            case YamlMappingNode mapping:
-                foreach (var (key, value) in mapping.Children)
-                {
-                    if (key is YamlScalarNode scalarKey
-                        && string.Equals(scalarKey.Value, "DependsOn", StringComparison.Ordinal)
-                        && NodeContainsReference(value, targetName))
-                    {
-                        return true;
-                    }
-
-                    if (NodeContainsReference(value, targetName))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-
-            default:
-                return false;
-        }
     }
 
     private static string GetSolutionRoot()

--- a/tests/Payslip4All.Web.Tests/Infrastructure/AwsDeploymentDocumentationTests.cs
+++ b/tests/Payslip4All.Web.Tests/Infrastructure/AwsDeploymentDocumentationTests.cs
@@ -13,10 +13,10 @@ public class AwsDeploymentDocumentationTests
         Assert.Contains("PERSISTENCE_PROVIDER=dynamodb", readme, StringComparison.Ordinal);
         Assert.Contains("DYNAMODB_REGION", readme, StringComparison.Ordinal);
         Assert.Contains("DYNAMODB_TABLE_PREFIX", readme, StringComparison.Ordinal);
-        Assert.Contains("AllowedSshCidr", readme, StringComparison.Ordinal);
         Assert.Contains("HostedPaymentsSecretArn", readme, StringComparison.Ordinal);
-        Assert.Contains("HostedZoneId", readme, StringComparison.Ordinal);
-        Assert.Contains("CertificateArn", readme, StringComparison.Ordinal);
+        Assert.Contains("TlsCertificateSecretArn", readme, StringComparison.Ordinal);
+        Assert.Contains("ASPNETCORE_URLS=http://127.0.0.1:8080", readme, StringComparison.Ordinal);
+        Assert.Contains("payslip4all.co.za", readme, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -27,39 +27,43 @@ public class AwsDeploymentDocumentationTests
 
         Assert.Equal(5, actions.Count);
         Assert.Contains(actions, action => action.Contains("Publish or upload the application artifact", StringComparison.Ordinal));
-        Assert.Contains(actions, action => action.Contains("ACM certificate", StringComparison.Ordinal));
-        Assert.Contains(actions, action => action.Contains("Route 53 hosted zone", StringComparison.Ordinal));
+        Assert.Contains(actions, action => action.Contains("TLS certificate secret", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(actions, action => action.Contains("Elastic IP", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(actions, action => action.Contains("payslip4all.co.za", StringComparison.Ordinal));
         Assert.Contains(actions, action => action.Contains("external secret references", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(actions, action => action.Contains("Launch `infra/aws/cloudformation/payslip4all-web.yaml`", StringComparison.Ordinal));
     }
 
     [Fact]
-    public void DeploymentGuide_DocumentsOperatorVisibleSignals_AndBehindAlbHealthChecks()
+    public void DeploymentGuide_DocumentsOperatorVisibleSignals_And_NginxSmokeChecks()
     {
         var readme = LoadDeploymentReadme();
 
         Assert.Contains("ApplicationUrl", readme, StringComparison.Ordinal);
+        Assert.Contains("ElasticIpAddress", readme, StringComparison.Ordinal);
         Assert.Contains("InstanceId", readme, StringComparison.Ordinal);
-        Assert.Contains("LoadBalancerArn", readme, StringComparison.Ordinal);
         Assert.Contains("InstanceSecurityGroupId", readme, StringComparison.Ordinal);
-        Assert.Contains("LoadBalancerSecurityGroupId", readme, StringComparison.Ordinal);
+        Assert.Contains("SsmStartSessionCommand", readme, StringComparison.Ordinal);
+        Assert.Contains("TlsCertificateSecretReference", readme, StringComparison.Ordinal);
         Assert.Contains("BackupProtectionMode", readme, StringComparison.Ordinal);
-        Assert.Contains("ALB target health", readme, StringComparison.Ordinal);
         Assert.Contains("/health", readme, StringComparison.Ordinal);
-        Assert.Contains("forwarded headers", readme, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("http://payslip4all.co.za", readme, StringComparison.Ordinal);
+        Assert.Contains("https://payslip4all.co.za", readme, StringComparison.Ordinal);
+        Assert.Contains("nginx -t", readme, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void DeploymentGuide_DocumentsDnsTls_CostTradeoffs_And_ReplaceableCompute()
+    public void DeploymentGuide_DocumentsElasticIpTlsConstraints_And_NoManagedEdgeAssumptions()
     {
         var readme = LoadDeploymentReadme();
 
         Assert.Contains("payslip4all.co.za", readme, StringComparison.Ordinal);
-        Assert.Contains("Application Load Balancer", readme, StringComparison.Ordinal);
-        Assert.Contains("Route 53", readme, StringComparison.Ordinal);
-        Assert.Contains("ACM", readme, StringComparison.Ordinal);
+        Assert.Contains("Elastic IP", readme, StringComparison.Ordinal);
+        Assert.Contains("nginx", readme, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("no-ALB", readme, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("no-Route53", readme, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("no-ACM", readme, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("free tier", readme, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("ALB", readme, StringComparison.Ordinal);
         Assert.Contains("replacing or recreating the EC2 instance", readme, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("public entry point remains the same", readme, StringComparison.OrdinalIgnoreCase);
     }
@@ -72,18 +76,19 @@ public class AwsDeploymentDocumentationTests
         Assert.Contains("point-in-time recovery", readme, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("restore", readme, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("restore to a new table", readme, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("60-minute", readme, StringComparison.Ordinal);
         Assert.Contains("/health", readme, StringComparison.Ordinal);
         Assert.Contains("infra/aws/cloudformation/payslip4all-web.yaml", readme, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void RootReadme_ReferencesCloudFormationDeploymentGuide()
+    public void RootReadme_ReferencesNginxAndCloudFormationDeploymentGuides()
     {
         var rootReadme = File.ReadAllText(Path.Combine(GetSolutionRoot(), "README.md"));
 
         Assert.Contains("AWS CloudFormation Deployment", rootReadme, StringComparison.Ordinal);
         Assert.Contains("infra/aws/cloudformation/README.md", rootReadme, StringComparison.Ordinal);
+        Assert.Contains("infra/nginx/README.md", rootReadme, StringComparison.Ordinal);
+        Assert.Contains("payslip4all.co.za", rootReadme, StringComparison.Ordinal);
     }
 
     private static string LoadDeploymentReadme()

--- a/tests/Payslip4All.Web.Tests/Infrastructure/NginxGatewayConfigTests.cs
+++ b/tests/Payslip4All.Web.Tests/Infrastructure/NginxGatewayConfigTests.cs
@@ -1,0 +1,78 @@
+namespace Payslip4All.Web.Tests.Infrastructure;
+
+public class NginxGatewayConfigTests
+{
+    [Fact]
+    public void GatewayConfig_DefinesHttpsSiteForProductionDomain_And_HttpRedirect()
+    {
+        var config = LoadNginxConfig();
+
+        Assert.Contains("server_name payslip4all.co.za;", config, StringComparison.Ordinal);
+        Assert.Contains("listen 80;", config, StringComparison.Ordinal);
+        Assert.Contains("listen 443 ssl http2;", config, StringComparison.Ordinal);
+        Assert.Contains("return 301 https://payslip4all.co.za$request_uri;", config, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GatewayConfig_UsesExternalCertificateFiles_And_LoopbackUpstream()
+    {
+        var config = LoadNginxConfig();
+
+        Assert.Contains("/etc/nginx/certs/fullchain.pem", config, StringComparison.Ordinal);
+        Assert.Contains("/etc/nginx/certs/privkey.pem", config, StringComparison.Ordinal);
+        Assert.Contains("server 127.0.0.1:8080;", config, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GatewayConfig_ForwardsProxyHeaders_WebSockets_And_Generic503Fallback()
+    {
+        var config = LoadNginxConfig();
+
+        Assert.Contains("proxy_set_header Host $host;", config, StringComparison.Ordinal);
+        Assert.Contains("proxy_set_header X-Real-IP $remote_addr;", config, StringComparison.Ordinal);
+        Assert.Contains("proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;", config, StringComparison.Ordinal);
+        Assert.Contains("proxy_set_header X-Forwarded-Proto https;", config, StringComparison.Ordinal);
+        Assert.Contains("proxy_set_header X-Forwarded-Host $host;", config, StringComparison.Ordinal);
+        Assert.Contains("proxy_set_header Upgrade $http_upgrade;", config, StringComparison.Ordinal);
+        Assert.Contains("proxy_set_header Connection $connection_upgrade;", config, StringComparison.Ordinal);
+        Assert.Contains("error_page 502 503 504 =503 /503.html;", config, StringComparison.Ordinal);
+        Assert.Contains("return 503 \"Service temporarily unavailable.", config, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GatewayReadme_ExplainsPrerequisites_ActivationInputs_And_Discoverability()
+    {
+        var readme = LoadNginxReadme();
+
+        Assert.Contains("infra/nginx/payslip4all.conf", readme, StringComparison.Ordinal);
+        Assert.Contains("payslip4all.co.za", readme, StringComparison.Ordinal);
+        Assert.Contains("fullchain.pem", readme, StringComparison.Ordinal);
+        Assert.Contains("privkey.pem", readme, StringComparison.Ordinal);
+        Assert.Contains("127.0.0.1:8080", readme, StringComparison.Ordinal);
+        Assert.Contains("bootstrap-payslip4all.sh", readme, StringComparison.Ordinal);
+        Assert.Contains("payslip4all-web.yaml", readme, StringComparison.Ordinal);
+        Assert.Contains("wrong-host", readme, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("nginx -t", readme, StringComparison.Ordinal);
+    }
+
+    private static string LoadNginxConfig()
+    {
+        return File.ReadAllText(Path.Combine(GetSolutionRoot(), "infra", "nginx", "payslip4all.conf"));
+    }
+
+    private static string LoadNginxReadme()
+    {
+        return File.ReadAllText(Path.Combine(GetSolutionRoot(), "infra", "nginx", "README.md"));
+    }
+
+    private static string GetSolutionRoot()
+    {
+        var currentDir = Directory.GetCurrentDirectory();
+        while (currentDir is not null && !File.Exists(Path.Combine(currentDir, "Payslip4All.sln")))
+        {
+            currentDir = Directory.GetParent(currentDir)?.FullName;
+        }
+
+        return currentDir ?? throw new InvalidOperationException("Could not find solution root.");
+    }
+}

--- a/tests/Payslip4All.Web.Tests/Integration/ReverseProxyForwardingTests.cs
+++ b/tests/Payslip4All.Web.Tests/Integration/ReverseProxyForwardingTests.cs
@@ -1,0 +1,147 @@
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Payslip4All.Web.Tests.Startup;
+
+namespace Payslip4All.Web.Tests.Integration;
+
+[Collection("WebIntegration")]
+public class ReverseProxyForwardingTests
+{
+    [Fact]
+    public async Task ForwardedHeaders_PreservePublicHttpsScheme_And_ForwardedHost()
+    {
+        using var factory = BuildFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/__proxy-test");
+        request.Headers.TryAddWithoutValidation("X-Forwarded-Proto", "https");
+        request.Headers.TryAddWithoutValidation("X-Forwarded-Host", "payslip4all.co.za");
+        request.Headers.Host = "127.0.0.1";
+
+        using var response = await client.SendAsync(request);
+        var payload = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("\"scheme\":\"https\"", payload, StringComparison.Ordinal);
+        Assert.Contains("\"host\":\"payslip4all.co.za\"", payload, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task HealthEndpoint_RemainsPublic_WhenForwardedThroughTheGatewayHost()
+    {
+        using var factory = BuildFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/health");
+        request.Headers.TryAddWithoutValidation("X-Forwarded-Proto", "https");
+        request.Headers.TryAddWithoutValidation("X-Forwarded-Host", "payslip4all.co.za");
+        request.Headers.Host = "127.0.0.1";
+
+        using var response = await client.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("\"status\":\"Healthy\"", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GatewayConfig_MapsUpstreamFailuresToGeneric503WithoutInternalAddressLeak()
+    {
+        var config = File.ReadAllText(Path.Combine(GetSolutionRoot(), "infra", "nginx", "payslip4all.conf"));
+
+        Assert.Contains("error_page 502 503 504 =503 /503.html;", config, StringComparison.Ordinal);
+        Assert.Contains("return 503 \"Service temporarily unavailable.", config, StringComparison.Ordinal);
+        Assert.DoesNotContain("127.0.0.1:8080", ExtractUnavailableResponse(config), StringComparison.Ordinal);
+    }
+
+    private static WebApplicationFactory<Program> BuildFactory()
+    {
+        return new TestWebApplicationFactory().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.AddSingleton<IStartupFilter, ProxyEchoStartupFilter>();
+            });
+        });
+    }
+
+    private static string ExtractUnavailableResponse(string config)
+    {
+        const string marker = "return 503 \"";
+        var start = config.IndexOf(marker, StringComparison.Ordinal);
+        if (start < 0)
+            return string.Empty;
+
+        start += marker.Length;
+        var end = config.IndexOf("\";", start, StringComparison.Ordinal);
+        return end < 0 ? config[start..] : config[start..end];
+    }
+
+    private static string GetSolutionRoot()
+    {
+        var currentDir = Directory.GetCurrentDirectory();
+        while (currentDir is not null && !File.Exists(Path.Combine(currentDir, "Payslip4All.sln")))
+        {
+            currentDir = Directory.GetParent(currentDir)?.FullName;
+        }
+
+        return currentDir ?? throw new InvalidOperationException("Could not find solution root.");
+    }
+
+    private sealed class ProxyEchoStartupFilter : IStartupFilter
+    {
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+        {
+            return app =>
+            {
+                app.Use(async (context, nextMiddleware) =>
+                {
+                    if (context.Request.Path == "/__proxy-test")
+                    {
+                        var options = app.ApplicationServices
+                            .GetRequiredService<IOptions<Microsoft.AspNetCore.Builder.ForwardedHeadersOptions>>()
+                            .Value;
+
+                        if (options.ForwardedHeaders.HasFlag(Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto))
+                        {
+                            var forwardedProto = context.Request.Headers["X-Forwarded-Proto"].ToString();
+                            if (!string.IsNullOrWhiteSpace(forwardedProto))
+                                context.Request.Scheme = forwardedProto;
+                        }
+
+                        if (options.ForwardedHeaders.HasFlag(Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedHost))
+                        {
+                            var forwardedHost = context.Request.Headers["X-Forwarded-Host"].ToString();
+                            if (!string.IsNullOrWhiteSpace(forwardedHost))
+                                context.Request.Host = HostString.FromUriComponent(forwardedHost);
+                        }
+
+                        context.Response.ContentType = "application/json";
+                        await context.Response.WriteAsJsonAsync(new
+                        {
+                            scheme = context.Request.Scheme,
+                            host = context.Request.Host.Value
+                        });
+                        return;
+                    }
+
+                    await nextMiddleware();
+                });
+
+                next(app);
+            };
+        }
+    }
+}

--- a/tests/Payslip4All.Web.Tests/Startup/AwsDeploymentStartupTests.cs
+++ b/tests/Payslip4All.Web.Tests/Startup/AwsDeploymentStartupTests.cs
@@ -1,8 +1,11 @@
 using Amazon.DynamoDBv2;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Payslip4All.Infrastructure.Persistence.DynamoDB;
 
 namespace Payslip4All.Web.Tests.Startup;
@@ -23,6 +26,36 @@ public sealed class AwsDeploymentStartupTests : IDisposable
 
         Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
         Assert.Contains("\"status\":\"Healthy\"", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReverseProxyStartup_TrustsForwardedHost_Proto_And_ClientIpHeaders()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var scope = factory.Services.CreateScope();
+
+        var options = scope.ServiceProvider
+            .GetRequiredService<IOptions<ForwardedHeadersOptions>>()
+            .Value;
+
+        Assert.Equal(
+            ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost,
+            options.ForwardedHeaders);
+        Assert.Empty(options.KnownNetworks);
+        Assert.Empty(options.KnownProxies);
+    }
+
+    [Fact]
+    public void AwsHostedDeployment_KeepsTheUpstreamOnLoopbackOnly()
+    {
+        var solutionRoot = GetSolutionRoot();
+        var bootstrap = File.ReadAllText(Path.Combine(solutionRoot, "infra", "aws", "cloudformation", "user-data", "bootstrap-payslip4all.sh"));
+        var template = File.ReadAllText(Path.Combine(solutionRoot, "infra", "aws", "cloudformation", "payslip4all-web.yaml"));
+
+        Assert.Contains("ASPNETCORE_URLS=http://127.0.0.1:8080", bootstrap, StringComparison.Ordinal);
+        Assert.Contains("ASPNETCORE_URLS=http://127.0.0.1:8080", template, StringComparison.Ordinal);
+        Assert.DoesNotContain("ASPNETCORE_URLS=http://0.0.0.0:80", bootstrap, StringComparison.Ordinal);
+        Assert.DoesNotContain("ASPNETCORE_URLS=http://0.0.0.0:80", template, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -85,5 +118,16 @@ public sealed class AwsDeploymentStartupTests : IDisposable
     {
         foreach (var (key, value) in _savedEnv)
             Environment.SetEnvironmentVariable(key, value);
+    }
+
+    private static string GetSolutionRoot()
+    {
+        var currentDir = Directory.GetCurrentDirectory();
+        while (currentDir is not null && !File.Exists(Path.Combine(currentDir, "Payslip4All.sln")))
+        {
+            currentDir = Directory.GetParent(currentDir)?.FullName;
+        }
+
+        return currentDir ?? throw new InvalidOperationException("Could not find solution root.");
     }
 }


### PR DESCRIPTION
## Summary
- add a repo-owned nginx config under infra for payslip4all.co.za
- terminate HTTPS, redirect HTTP to HTTPS, and reverse proxy traffic to 127.0.0.1:8080
- align AWS deployment assets, forwarded-header handling, and web tests with the new gateway setup

## Testing
- dotnet test tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj --no-restore --filter "FullyQualifiedName~NginxGatewayConfigTests|FullyQualifiedName~ReverseProxyForwardingTests|FullyQualifiedName~AwsCloudFormationTemplateTests|FullyQualifiedName~AwsDeploymentDocumentationTests|FullyQualifiedName~AwsDeploymentStartupTests"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * HTTPS now served via nginx reverse proxy at payslip4all.co.za
  * HTTP traffic automatically redirects to HTTPS
  * Streamlined certificate and infrastructure management

* **Documentation & Testing**
  * Added nginx gateway configuration documentation and operator guides
  * Enhanced deployment validation and test coverage for the new architecture

<!-- end of auto-generated comment: release notes by coderabbit.ai -->