### PR TITLE
Add LocalStack adhir-server workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.gitignore
+.github/
+.specify/
+**/bin/
+**/obj/
+TestResults/
+coverage/
+dist/
+node_modules/
+*.log
+.env*
+.DS_Store
+Thumbs.db
+.vscode/
+.idea/

--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -1,6 +1,6 @@
 # payslip4all Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-23
+Auto-generated from all feature plans. Last updated: 2026-04-24
 
 ## Active Technologies
 - C# 12 / .NET 8 (LTS) + Blazor Server (ASP.NET Core 8), Entity Framework Core 8, QuestPDF 2024.10.4, BCrypt.Net-Next 4.0.3, Pomelo.EntityFrameworkCore.MySql 8.0.2 (001-payslip-generation)
@@ -51,6 +51,8 @@ Auto-generated from all feature plans. Last updated: 2026-04-23
 - N/A (no application persistence or schema changes) (013-nginx-https-proxy)
 - C# 12 / .NET 8 (LTS), Bash, and AWS CloudFormation YAML + ASP.NET Core 8 Blazor Server, existing `awscli`/`jq` bootstrap flow under `/infra/aws/cloudformation/`, Serilog, xUnit + WebApplicationFactory, existing `AWSSDK.DynamoDBv2` runtime path (014-aws-secrets-config)
 - N/A for business persistence; configuration resolves from checked-in JSON, deployment environment variables, and an optional bootstrap-rendered AWS-secrets JSON artifac (014-aws-secrets-config)
+- C# 12 / .NET 8 (LTS), Dockerfile, Markdown documentation + ASP.NET Core Blazor Server, `AWSSDK.DynamoDBv2`, LocalStack Docker image, xUnit, `Microsoft.AspNetCore.Mvc.Testing` (016-localstack-dynamodb-dockerfile)
+- DynamoDB via LocalStack emulator for local development; no production or schema-model changes (016-localstack-dynamodb-dockerfile)
 
 - C# 12 / .NET 8 (LTS) + ASP.NET Core Blazor Server, Entity Framework Core 8, QuestPDF, BCrypt.Net-Next, Pomelo.EntityFrameworkCore.MySql, Microsoft.EntityFrameworkCore.Sqlite, bUnit, xUnit, Moq (001-payslip-generation)
 
@@ -71,9 +73,9 @@ tests/
 C# 12 / .NET 8 (LTS): Follow standard conventions
 
 ## Recent Changes
+- 016-localstack-dynamodb-dockerfile: Added C# 12 / .NET 8 (LTS), Dockerfile, Markdown documentation + ASP.NET Core Blazor Server, `AWSSDK.DynamoDBv2`, LocalStack Docker image, xUnit, `Microsoft.AspNetCore.Mvc.Testing`
 - 014-aws-secrets-config: Added C# 12 / .NET 8 (LTS), Bash, and AWS CloudFormation YAML + ASP.NET Core 8 Blazor Server, existing `awscli`/`jq` bootstrap flow under `/infra/aws/cloudformation/`, Serilog, xUnit + WebApplicationFactory, existing `AWSSDK.DynamoDBv2` runtime path
 - 013-nginx-https-proxy: Added nginx configuration, Bash bootstrap scripting, and existing C# 12 / .NET 8 application runtime + nginx, ASP.NET Core 8 reverse-proxy support, AWS CloudFormation/EC2/Secrets Manager deployment assets, Serilog request logging, xUnit + WebApplicationFactory
-- 009-payfast-card-integration: Added C# 12 on .NET 8 / ASP.NET Core 8 Blazor Web App + ASP.NET Core Blazor Server, Entity Framework Core 8, `AWSSDK.DynamoDBv2`, Serilog, xUnit, bUnit, Moq, PayFast hosted-payment integration
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/README.md
+++ b/README.md
@@ -123,20 +123,47 @@ Migrations are applied automatically on startup for SQLite and MySQL.
 #### Local DynamoDB emulator
 
 ```bash
-docker run -d --name dynamodb-local -p 8000:8000 amazon/dynamodb-local \
-  -jar DynamoDBLocal.jar -sharedDb -inMemory
+docker -H ssh://adhir-server build -f infra/localstack/Dockerfile -t payslip4all-localstack .
+docker -H ssh://adhir-server run --rm --name payslip4all-localstack -p 8000:8000 payslip4all-localstack
 
 export PERSISTENCE_PROVIDER=dynamodb
 export DYNAMODB_REGION=us-east-1
-export DYNAMODB_ENDPOINT=http://localhost:8000
+export DYNAMODB_ENDPOINT=http://adhir-server:8000
 export DYNAMODB_TABLE_PREFIX=payslip4all
+
+dotnet test tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj --filter Category=Integration
 
 cd src/Payslip4All.Web
 dotnet run
+
+docker -H ssh://adhir-server stop payslip4all-localstack
 ```
+
+The LocalStack Dockerfile lives at `infra/localstack/Dockerfile` and the full operator guide lives at `infra/localstack/README.md`. This workflow is intended for **development and smoke testing** with `DynamoDbLocalStartupTests`, `DynamoDbLocalWorkflowTests`, and local manual verification.
+
+The Docker commands above target the Docker daemon on `adhir-server`. If you run the application or tests from a shell on `adhir-server` itself, you can keep `DYNAMODB_ENDPOINT=http://localhost:8000` instead.
 
 If `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are both unset while `DYNAMODB_ENDPOINT`
 is configured, the app supplies dummy credentials automatically for local emulators.
+
+Recommended LocalStack verification from the repository root:
+
+```bash
+dotnet test tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj --filter Category=Integration
+```
+
+Run that verification before stopping the LocalStack container on `adhir-server`.
+
+Configurable local values:
+
+- `DYNAMODB_ENDPOINT=http://adhir-server:8000` keeps the documented remote LocalStack port. If port `8000` is already in use on `adhir-server`, choose a different host port in `docker run` and update `DYNAMODB_ENDPOINT` to match.
+- `DYNAMODB_TABLE_PREFIX=payslip4all` controls the prefixed local table names so contributors can avoid collisions.
+
+Local troubleshooting:
+
+- If the app cannot reach the emulator, check that the LocalStack container is still running and that `DYNAMODB_ENDPOINT` matches the current `docker run` port mapping.
+- If startup fails immediately, confirm `DYNAMODB_REGION` is set and that explicit credentials are either both set or both omitted.
+- Use the dedicated LocalStack guide in `infra/localstack/README.md` for build, run, stop, verify, and troubleshooting details.
 
 #### Hosted AWS
 
@@ -394,6 +421,7 @@ dotnet test tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj
 When `DYNAMODB_ENDPOINT` is configured for a local emulator, you can additionally run the DynamoDB integration repository suite.
 
 ```bash
+dotnet test tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj --filter Category=Integration
 dotnet test tests/Payslip4All.Infrastructure.Tests/Payslip4All.Infrastructure.Tests.csproj --filter "Category=Integration"
 ```
 

--- a/infra/localstack/LocalStackDockerfile
+++ b/infra/localstack/LocalStackDockerfile
@@ -1,0 +1,11 @@
+# Development-only LocalStack runtime for the repository's local DynamoDB smoke tests.
+FROM localstack/localstack:3.5
+
+ENV SERVICES=dynamodb \
+    GATEWAY_LISTEN=0.0.0.0:8000 \
+    EDGE_PORT=8000 \
+    AWS_DEFAULT_REGION=us-east-1 \
+    EAGER_SERVICE_LOADING=1 \
+    PERSISTENCE=0
+
+EXPOSE 8000

--- a/infra/localstack/README.md
+++ b/infra/localstack/README.md
@@ -1,0 +1,65 @@
+# LocalStack DynamoDB development container
+
+Use this image for **development and smoke testing only**. It pins a DynamoDB-only LocalStack runtime to the repository's documented local endpoint contract without requiring a live AWS account.
+
+## Build
+
+From the repository root:
+
+```bash
+docker -H ssh://adhir-server build -f infra/localstack/Dockerfile -t payslip4all-localstack .
+```
+
+## Run
+
+```bash
+docker -H ssh://adhir-server run --rm --name payslip4all-localstack -p 8000:8000 payslip4all-localstack
+```
+
+The container must remain running while the application or tests use the emulator. These commands target the Docker daemon on `adhir-server`.
+
+## Configure the app or tests
+
+```bash
+export PERSISTENCE_PROVIDER=dynamodb
+export DYNAMODB_REGION=us-east-1
+export DYNAMODB_ENDPOINT=http://adhir-server:8000
+export DYNAMODB_TABLE_PREFIX=payslip4all
+```
+
+If you open a shell directly on `adhir-server` to run the application or tests there, you can keep `DYNAMODB_ENDPOINT=http://localhost:8000` instead.
+
+If `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are both unset, the app supplies emulator-safe dummy credentials automatically. This local workflow does not require a live AWS account. If you do set explicit credentials, provide the paired explicit credentials together.
+
+## Verify the LocalStack workflow
+
+Run the LocalStack-focused integration suite from the repository root:
+
+```bash
+dotnet test tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj --filter Category=Integration
+```
+
+This verifies that startup provisioning can create the prefixed DynamoDB tables and that representative local repository workflows succeed against the configured endpoint.
+Run this verification while the container is still running, then stop the emulator afterward.
+
+## Stop the emulator
+
+Stop the foreground container with `Ctrl+C`, or from another terminal run:
+
+```bash
+docker -H ssh://adhir-server stop payslip4all-localstack
+```
+
+## Configurable values
+
+- `DYNAMODB_ENDPOINT` defaults to `http://adhir-server:8000` in the documented remote workflow. If port `8000` is already in use on `adhir-server`, choose a different host port in `docker run` and update `DYNAMODB_ENDPOINT` to match.
+- `DYNAMODB_TABLE_PREFIX` controls the table-name prefix used for local tables so contributors can avoid naming collisions.
+- `DYNAMODB_REGION` should stay aligned with the documented LocalStack contract unless you intentionally need a different local region.
+
+## Troubleshooting
+
+- If port `8000` is already in use, free the port or choose a different host port and update `DYNAMODB_ENDPOINT` consistently.
+- If startup fails because configuration validation rejects the endpoint, make sure `DYNAMODB_ENDPOINT` is an absolute `http://` or `https://` URL.
+- If the app cannot reach the emulator, check that the container is still running, confirm `DYNAMODB_ENDPOINT` matches the `docker run` port mapping, and verify the LocalStack container finished starting.
+- If startup fails immediately, confirm `DYNAMODB_REGION` is set and that paired explicit credentials are either both set or both omitted.
+- If the integration workflow fails after a partial run, stop the container, restart it, and rerun the integration test command with a clean local session.

--- a/specs/016-localstack-dynamodb-dockerfile/checklists/requirements.md
+++ b/specs/016-localstack-dynamodb-dockerfile/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Local DynamoDB Development Environment
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validated on 2026-04-24 against `spec.md`; all checklist items passed on the first review and no clarification questions are required before planning.

--- a/specs/016-localstack-dynamodb-dockerfile/contracts/local-dynamodb-runtime.md
+++ b/specs/016-localstack-dynamodb-dockerfile/contracts/local-dynamodb-runtime.md
@@ -1,0 +1,73 @@
+# Contract: Local DynamoDB Runtime
+
+## Purpose
+
+Define the contributor-facing interface for the repository's LocalStack-backed DynamoDB development environment.
+
+## Artifact Contract
+
+| Item | Contract |
+|---|---|
+| Dockerfile path | `infra/localstack/Dockerfile` |
+| Image purpose | Provide a DynamoDB-compatible local service for development and integration testing |
+| Base image | Explicit LocalStack version tag |
+| Enabled service set | DynamoDB only |
+| Exposed container port | `8000` |
+| Host endpoint | `http://adhir-server:8000` |
+
+## Build and Run Contract
+
+### Build
+
+```bash
+docker -H ssh://adhir-server build -f infra/localstack/Dockerfile -t payslip4all-localstack .
+```
+
+### Run
+
+```bash
+docker -H ssh://adhir-server run --rm --name payslip4all-localstack -p 8000:8000 payslip4all-localstack
+```
+
+## Application Runtime Contract
+
+To consume the local emulator, contributors must supply the standard DynamoDB runtime settings:
+
+```bash
+export PERSISTENCE_PROVIDER=dynamodb
+export DYNAMODB_REGION=us-east-1
+export DYNAMODB_ENDPOINT=http://adhir-server:8000
+export DYNAMODB_TABLE_PREFIX=payslip4all
+```
+
+### Credential expectations
+
+- If `DYNAMODB_ENDPOINT` is set and explicit AWS credentials are not provided, the application must be able to use emulator-safe dummy credentials automatically.
+- If explicit credentials are supplied, both access key and secret key must be present together.
+- A live AWS account must not be required for this local workflow.
+
+## Expected Behavior
+
+- Starting the container exposes a DynamoDB-compatible endpoint on `http://adhir-server:8000`.
+- Starting the app with the runtime contract above uses the DynamoDB provider path instead of relational providers.
+- Existing startup provisioning creates or verifies required prefixed tables for local use.
+- Integration and smoke-test workflows can run against the emulator without source-code changes.
+
+## Verification Contract
+
+The feature is considered integrated when contributors can use the runtime contract above and a representative validation command succeeds, such as:
+
+```bash
+dotnet test tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj --filter Category=Integration
+```
+
+That verification command must run before the LocalStack container is stopped.
+
+## Failure Signals
+
+| Failure | Expected Guidance |
+|---|---|
+| Port `8000` already in use | Documentation must explain how to free the port or remap/update the local endpoint consistently |
+| Container starts but app cannot connect | Documentation must direct contributors to check `DYNAMODB_ENDPOINT`, region, and container status |
+| `PERSISTENCE_PROVIDER=dynamodb` but region missing | Startup validation must fail with a clear configuration error |
+| One explicit AWS credential is missing | Startup validation must fail with a clear paired-credential error |

--- a/specs/016-localstack-dynamodb-dockerfile/data-model.md
+++ b/specs/016-localstack-dynamodb-dockerfile/data-model.md
@@ -1,0 +1,56 @@
+# Data Model: Local DynamoDB Development Environment
+
+## Entity: LocalStack Image Configuration
+
+**Purpose**: Defines the source-controlled container settings that expose a DynamoDB-compatible local service for contributors.
+
+| Field | Type | Description | Validation |
+|---|---|---|---|
+| `baseImageTag` | string | Pinned LocalStack image tag used by the repository Dockerfile | Must be an explicit non-empty tag, not a floating placeholder |
+| `enabledServices` | string list | AWS service set enabled inside the image | Must include DynamoDB; should not enable unrelated services without justification |
+| `listenAddress` | string | Container bind address for the LocalStack gateway | Must allow host reachability for the documented local run mode |
+| `listenPort` | integer | Port exposed for the local DynamoDB endpoint | Must match documented build/run instructions and test expectations |
+| `defaultRegion` | string | Default AWS region used for local startup | Must align with documented local configuration |
+| `eagerServiceLoading` | boolean | Whether DynamoDB is initialized during container startup | Must support predictable readiness for smoke tests |
+| `persistenceMode` | boolean | Whether emulator state is persisted across restarts | Defaults to ephemeral local runs for clean validation |
+
+## Entity: Local DynamoDB Runtime Contract
+
+**Purpose**: Represents the environment values a contributor uses to connect the application or tests to the emulator.
+
+| Field | Type | Description | Validation |
+|---|---|---|---|
+| `persistenceProvider` | string | Application persistence provider selector | Must be `dynamodb` for this workflow |
+| `region` | string | Region value consumed by DynamoDB client configuration | Required and non-empty |
+| `endpoint` | URI string | Local DynamoDB-compatible endpoint | Required for the local emulator path; must be a valid HTTP URL |
+| `tablePrefix` | string | Prefix used for locally provisioned DynamoDB tables | Must be non-empty and safe for repeated local runs |
+| `credentialMode` | enum (`explicit`, `emulator-default`) | How credentials are resolved for the runtime | Must be internally consistent with endpoint presence and app validation rules |
+
+## Entity: Developer Verification Workflow
+
+**Purpose**: Describes the contributor journey used to verify the local emulator is usable.
+
+| Field | Type | Description | Validation |
+|---|---|---|---|
+| `buildCommand` | string | Command used to build the local image | Must resolve from repo root |
+| `runCommand` | string | Command used to start the container | Must expose the documented local port |
+| `readinessSignal` | string | Observable signal that the local service is usable | Must be checkable by documentation or tests |
+| `smokeTestCommand` | string | Command used to validate DynamoDB-backed behavior locally | Must run against the documented endpoint contract |
+| `troubleshootingGuide` | string | Pointer to contributor-facing failure guidance | Must exist in repository documentation |
+
+## Relationships
+
+- **LocalStack Image Configuration** produces one **Local DynamoDB Runtime Contract**.
+- **Local DynamoDB Runtime Contract** is consumed by one or more **Developer Verification Workflow** executions.
+- **Developer Verification Workflow** validates that the runtime contract stays compatible with existing application startup and test expectations.
+
+## State Transitions
+
+### Local emulator lifecycle
+
+1. `Not Built` -> `Built`: Contributor builds the LocalStack image from the repository Dockerfile.
+2. `Built` -> `Running`: Contributor starts the container with the documented port mapping.
+3. `Running` -> `Reachable`: The endpoint is available and the app/tests can connect using the documented configuration.
+4. `Reachable` -> `Verified`: Startup and smoke-test workflows complete successfully.
+5. `Running` or `Reachable` -> `Failed`: Port conflict, misconfiguration, or container startup issues prevent successful use.
+6. `Verified` -> `Stopped`: Contributor stops or removes the container, ending the ephemeral local session.

--- a/specs/016-localstack-dynamodb-dockerfile/plan.md
+++ b/specs/016-localstack-dynamodb-dockerfile/plan.md
@@ -1,0 +1,96 @@
+# Implementation Plan: Local DynamoDB Development Environment
+
+**Branch**: `016-localstack-dynamodb-dockerfile` | **Date**: 2026-04-24 | **Spec**: `/Users/adhirramjiawan/projects/payslip4all/specs/016-localstack-dynamodb-dockerfile/spec.md`
+**Input**: Feature specification from `/Users/adhirramjiawan/projects/payslip4all/specs/016-localstack-dynamodb-dockerfile/spec.md`
+
+## Summary
+
+Align the repository's LocalStack-based DynamoDB development environment with the current DynamoDB provider path by refining the source-controlled Docker image contract, preserving the existing `http://localhost:8000` integration-test workflow, and tightening documentation and verification so contributors can build, run, and troubleshoot the local emulator without using live AWS resources.
+
+## Technical Context
+
+**Language/Version**: C# 12 / .NET 8 (LTS), Dockerfile, Markdown documentation  
+**Primary Dependencies**: ASP.NET Core Blazor Server, `AWSSDK.DynamoDBv2`, LocalStack Docker image, xUnit, `Microsoft.AspNetCore.Mvc.Testing`  
+**Storage**: DynamoDB via LocalStack emulator for local development; no production or schema-model changes  
+**Testing**: xUnit integration and infrastructure configuration tests in `tests/Payslip4All.Web.Tests`  
+**Target Platform**: Docker-capable developer workstation running the app and DynamoDB emulator locally on `http://localhost:8000`  
+**Project Type**: Web application with supporting infrastructure artifact and developer documentation  
+**Performance Goals**: Contributors can start and verify the local emulator within the success criteria defined by the spec; startup remains predictable for integration tests and local smoke testing  
+**Constraints**: No live AWS dependency, preserve existing `PERSISTENCE_PROVIDER=dynamodb` startup contract, keep the setup source-controlled and reproducible, avoid changes to business logic or persistence abstractions  
+**Scale/Scope**: One LocalStack Docker artifact, related documentation, and verification coverage across existing web/integration test surfaces
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Verify compliance with each Payslip4All constitution principle before proceeding:
+
+| # | Principle | Gate Question | Status |
+|---|-----------|---------------|--------|
+| I | TDD | Are failing tests planned/written before any implementation task begins? | PASS |
+| II | Clean Architecture | Does the feature touch ≤ 4 projects (Domain/Application/Infrastructure/Web)? Does each layer only depend inward? | PASS |
+| III | Blazor Web App | Are all new UI surfaces Razor components? Is business logic kept out of `.razor` files? | PASS |
+| IV | Basic Authentication | Do new pages carry `[Authorize]`? Do new service methods filter by `UserId`? | PASS |
+| V | Database Support | For EF Core providers (SQLite/MySQL): are all schema changes EF Core migrations? Is raw SQL avoided? For DynamoDB provider (`PERSISTENCE_PROVIDER=dynamodb`): do DynamoDB repositories implement all Application interfaces? Is ownership filtering enforced? | PASS |
+| VI | Manual Test Gate | Is the Manual Test Gate prompt planned at the end of each implementation task, before any `git commit`, `git merge`, or `git push`? | PASS |
+
+**Pre-design assessment**:
+- TDD remains mandatory even though the feature centers on infrastructure and docs; implementation must start with failing tests around the LocalStack artifact and any updated runtime expectations.
+- The feature stays within existing repository boundaries: `infra/localstack`, `README.md`, and `tests/Payslip4All.Web.Tests`, with possible limited updates to existing DynamoDB startup wiring only if tests prove necessary.
+- No constitution deviations or exceptions are required.
+
+**Post-design re-check**:
+- Phase 0 and Phase 1 artifacts keep the feature inside the existing DynamoDB provider path and avoid new architectural or authentication surface area.
+- No unresolved clarifications remain, and no constitution gate is blocked by the current design.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/016-localstack-dynamodb-dockerfile/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── local-dynamodb-runtime.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+infra/
+└── localstack/
+    ├── Dockerfile
+    └── README.md
+
+src/
+├── Payslip4All.Infrastructure/
+│   └── Persistence/
+│       └── DynamoDB/
+│           ├── DynamoDbClientFactory.cs
+│           ├── DynamoDbConfigurationOptions.cs
+│           ├── DynamoDbServiceExtensions.cs
+│           └── DynamoDbTableProvisioner.cs
+└── Payslip4All.Web/
+    └── Program.cs
+
+tests/
+└── Payslip4All.Web.Tests/
+    ├── Infrastructure/
+    │   └── LocalStackIntegrationConfigTests.cs
+    ├── Integration/
+    │   └── DynamoDbLocalStartupTests.cs
+    └── Startup/
+        └── DynamoDbConfigurationValidationTests.cs
+
+README.md
+```
+
+**Structure Decision**: Keep the feature scoped to the existing infrastructure asset, web startup contract, and web test suite. No new project, package, or deployment surface is needed; implementation should refine `infra/localstack` and the existing DynamoDB startup/test workflow already used by the repository.
+
+## Complexity Tracking
+
+No constitution violations or justified exceptions are required for this feature.

--- a/specs/016-localstack-dynamodb-dockerfile/quickstart.md
+++ b/specs/016-localstack-dynamodb-dockerfile/quickstart.md
@@ -1,0 +1,65 @@
+# Quickstart: Local DynamoDB Development Environment
+
+## 1. Build the LocalStack image
+
+From the repository root:
+
+```bash
+docker -H ssh://adhir-server build -f infra/localstack/Dockerfile -t payslip4all-localstack .
+```
+
+This workflow is for local development and smoke testing only. The contributor-facing operator guide lives at `infra/localstack/README.md`.
+
+## 2. Start the local DynamoDB emulator
+
+```bash
+docker -H ssh://adhir-server run --rm --name payslip4all-localstack -p 8000:8000 payslip4all-localstack
+```
+
+The container must remain running while the application or tests use the local DynamoDB endpoint on `adhir-server`.
+
+## 3. Configure the application for the local DynamoDB path
+
+In a second terminal:
+
+```bash
+export PERSISTENCE_PROVIDER=dynamodb
+export DYNAMODB_REGION=us-east-1
+export DYNAMODB_ENDPOINT=http://adhir-server:8000
+export DYNAMODB_TABLE_PREFIX=payslip4all
+```
+
+If explicit AWS credentials are not set, the app should use emulator-safe dummy credentials automatically for this local endpoint.
+If explicit credentials are supplied, both `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` must be present together.
+If you run the application or tests from a shell on `adhir-server` itself, you can substitute `http://localhost:8000`.
+
+## 4. Verify the emulator with the existing integration workflow
+
+```bash
+dotnet test tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj --filter Category=Integration
+```
+
+This verifies that startup can provision the expected prefixed tables and that representative repository behavior works against the local endpoint.
+
+## 5. Run the application locally against DynamoDB
+
+```bash
+cd src/Payslip4All.Web
+dotnet run
+```
+
+## 6. Stop the local environment
+
+After the integration test command above completes, stop the running container with `Ctrl+C`, or terminate it from another terminal:
+
+```bash
+docker -H ssh://adhir-server stop payslip4all-localstack
+```
+
+## Troubleshooting
+
+- If port `8000` is already in use, free the port or choose a different host port and update `DYNAMODB_ENDPOINT` to match.
+- If you choose a different host port, keep the `docker run` port mapping and `DYNAMODB_ENDPOINT` aligned.
+- If startup fails immediately, confirm `DYNAMODB_REGION` is set and that paired explicit credentials are either both set or both omitted.
+- If the application cannot reach the emulator, check that the container is still running and `DYNAMODB_ENDPOINT` still points to `http://adhir-server:8000`.
+- If integration tests fail after partial setup, restart the container and rerun the tests with a clean local session.

--- a/specs/016-localstack-dynamodb-dockerfile/research.md
+++ b/specs/016-localstack-dynamodb-dockerfile/research.md
@@ -1,0 +1,49 @@
+# Research: Local DynamoDB Development Environment
+
+## Decision 1: Keep a DynamoDB-only LocalStack image pinned to an explicit base version
+
+- **Decision**: Continue using a dedicated `infra/localstack/Dockerfile` based on an explicitly pinned LocalStack image (`localstack/localstack:3.5`) and keep the container limited to DynamoDB.
+- **Rationale**: The repository already uses a single-purpose LocalStack image that exposes only the DynamoDB emulator on port `8000`, which matches the existing integration-test default and reduces local startup variability. A pinned image version preserves reproducibility across contributor machines and CI-style smoke testing.
+- **Alternatives considered**:
+  - `latest` or floating major tags: rejected because they weaken reproducibility and can break local setup unexpectedly.
+  - Multi-service LocalStack image: rejected because this feature only needs DynamoDB and extra services add noise, startup time, and maintenance burden.
+
+## Decision 2: Preserve the existing local runtime contract around `http://localhost:8000`
+
+- **Decision**: Keep the local emulator contract centered on `PERSISTENCE_PROVIDER=dynamodb`, `DYNAMODB_REGION=us-east-1`, `DYNAMODB_ENDPOINT=http://localhost:8000`, and a configurable `DYNAMODB_TABLE_PREFIX`.
+- **Rationale**: `Program.cs`, `DynamoDbConfigurationOptions`, `DynamoDbClientFactory`, README guidance, and `DynamoDbLocalStartupTests` already align around that contract. Preserving it means contributors and tests use one documented setup instead of inventing a parallel local-only path.
+- **Alternatives considered**:
+  - New feature-specific configuration keys: rejected because the repo already centralizes DynamoDB configuration and validates it at startup.
+  - Dynamic endpoint discovery: rejected because deterministic local documentation and test setup are more valuable than added flexibility here.
+
+## Decision 3: Rely on emulator-friendly dummy credentials when a local endpoint is configured
+
+- **Decision**: Keep the existing credential pattern where explicit AWS credentials are optional for local emulators and dummy credentials are supplied automatically when `DYNAMODB_ENDPOINT` is set.
+- **Rationale**: `DynamoDbClientFactory` already protects the local workflow by providing syntactically valid credentials for emulator use while still allowing the AWS SDK credential chain for hosted AWS. This keeps local onboarding simple and avoids teaching contributors to manage unnecessary local secrets.
+- **Alternatives considered**:
+  - Requiring contributors to export dummy credentials manually: rejected because the application already handles this more safely and consistently.
+  - Hardcoding credentials in docs or source: rejected for security and maintainability reasons.
+
+## Decision 4: Keep the local emulator ephemeral and eager to start
+
+- **Decision**: Retain the current LocalStack runtime choices of `SERVICES=dynamodb`, `GATEWAY_LISTEN=0.0.0.0:8000`, `EAGER_SERVICE_LOADING=1`, and `PERSISTENCE=0`.
+- **Rationale**: These settings fit the repo's current workflow: DynamoDB-only startup, deterministic port binding, low ceremony for local smoke tests, and clean-state runs that avoid stale local data interfering with prefixed test tables. The current infrastructure tests already verify the most important parts of this contract.
+- **Alternatives considered**:
+  - Enabling persistence: rejected because the integration-test path benefits from ephemeral state and table cleanup.
+  - Standard LocalStack edge port `4566`: rejected because the repository already documents and tests `8000`.
+
+## Decision 5: Validate the feature through documentation and startup/integration tests, not a new abstraction layer
+
+- **Decision**: Plan implementation around failing tests in `tests/Payslip4All.Web.Tests` plus documentation updates in `README.md` and `infra/localstack/README.md`.
+- **Rationale**: The repo already has coverage for LocalStack Dockerfile configuration, startup validation, provider switching, and end-to-end DynamoDB create/read provisioning. Extending those surfaces is the shortest path that keeps the feature aligned with TDD and avoids unnecessary architectural churn.
+- **Alternatives considered**:
+  - Creating a new tooling project or helper CLI just to manage LocalStack: rejected because the feature scope is a source-controlled infrastructure artifact, not a new application subsystem.
+  - Relying on manual verification only: rejected because the constitution requires tests to lead implementation.
+
+## Decision 6: Treat the contributor-facing runtime contract as the feature's external interface
+
+- **Decision**: Document the local LocalStack build/run contract in a dedicated contract artifact under `contracts/`, covering build command, run command, exposed port, required app environment variables, readiness expectation, and troubleshooting signals.
+- **Rationale**: Even though this feature is infrastructure-focused, contributors interact with it through a stable interface: a Docker image plus runtime settings. Capturing that contract explicitly makes planning and later task generation clearer.
+- **Alternatives considered**:
+  - No contract artifact: rejected because the planning workflow expects contracts where a user- or system-facing interface exists.
+  - Embedding all interface rules only in README prose: rejected because it weakens the separation between design contract and how-to guidance.

--- a/specs/016-localstack-dynamodb-dockerfile/spec.md
+++ b/specs/016-localstack-dynamodb-dockerfile/spec.md
@@ -1,0 +1,104 @@
+# Feature Specification: Local DynamoDB Development Environment
+
+**Feature Branch**: `016-localstack-dynamodb-dockerfile`  
+**Created**: 2026-04-24  
+**Status**: Draft  
+**Input**: User description: "Create a Dockerfile for a LocalStack instance mocking DynamoDB for local development."
+
+## Architecture & TDD Alignment *(mandatory for Payslip4All)*
+
+- **Domain**: No payroll, employee, loan, or payslip business rules change in this feature.
+- **Application**: Existing use cases and persistence contracts remain unchanged; this feature only supports how contributors satisfy local development dependencies.
+- **Infrastructure**: This feature adds a source-controlled local development environment artifact that provides a DynamoDB-compatible persistence service for workstation use.
+- **Web**: The application must be able to run local DynamoDB-dependent workflows against the local persistence service without changing end-user behaviour.
+- **TDD Alignment**: Each functional requirement below is expressed as observable developer-facing behaviour so setup validation, startup verification, and local smoke tests can be written before implementation.
+
+### User Story 1 - Start a local persistence service (Priority: P1)
+
+As a developer, I want a reusable local persistence service that emulates the DynamoDB dependency so I can develop and validate DynamoDB-backed behaviour without using shared cloud resources.
+
+**Why this priority**: A working local service is the minimum value of this feature. Without it, the team cannot perform DynamoDB-related development or smoke testing consistently on a workstation.
+
+**Independent Test**: From a repository checkout on a prepared workstation, start the provided local environment artifact and verify that a DynamoDB-compatible local service becomes available for development use without requiring a live AWS account.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer has the repository and required local runtime prerequisites, **When** they start the provided local persistence environment, **Then** a DynamoDB-compatible service becomes available on the developer machine for local development.
+2. **Given** the local persistence environment is already running, **When** the developer restarts it using the same repository state, **Then** the service starts predictably with the same documented connection details and usage expectations.
+
+---
+
+### User Story 2 - Use local DynamoDB-backed workflows (Priority: P2)
+
+As a developer, I want the application and local validation workflows to use the emulated persistence service so I can test DynamoDB-dependent behaviour before deploying to a shared environment.
+
+**Why this priority**: Starting a local service is only useful if contributors can point their local workflows at it and complete meaningful validation of DynamoDB-backed behaviour.
+
+**Independent Test**: Start the local persistence service, point the application or smoke-test workflow at it using the documented local settings, and verify representative DynamoDB-dependent operations complete successfully.
+
+**Acceptance Scenarios**:
+
+1. **Given** the local persistence service is available, **When** a developer runs a DynamoDB-dependent local workflow using the documented local settings, **Then** the workflow completes successfully against the emulated service.
+2. **Given** the local persistence service is unavailable or misconfigured, **When** a developer attempts to run a DynamoDB-dependent local workflow, **Then** they receive clear guidance that the local persistence dependency is not ready.
+
+---
+
+### User Story 3 - Reuse a standard team setup (Priority: P3)
+
+As a contributor, I want the local persistence setup stored and documented in the repository so I can discover, run, and troubleshoot the same development dependency used by the rest of the team.
+
+**Why this priority**: Standardized setup reduces onboarding friction and local-environment drift, but it depends on the higher-priority ability to start and use the local service successfully.
+
+**Independent Test**: Ask a contributor unfamiliar with the setup to locate the local persistence artifact and follow the documented steps to start and verify the service without needing extra tribal knowledge.
+
+**Acceptance Scenarios**:
+
+1. **Given** a contributor is new to the repository, **When** they inspect the repository and setup guidance, **Then** they can identify how to start, stop, and verify the local persistence service.
+2. **Given** two contributors use the same repository state on separate workstations, **When** each follows the documented setup steps, **Then** both obtain the same local persistence capability for DynamoDB-related development.
+
+---
+
+### Edge Cases
+
+- What happens when the developer machine already uses the default local port or has another conflicting local service running?
+- How does the setup behave when the local persistence service starts successfully but the application cannot reach it with the documented connection settings?
+- What happens when a contributor attempts to use the local persistence workflow without a live AWS account or shared cloud access?
+- How is failure guidance presented when required local runtime prerequisites are missing or unavailable?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The feature MUST provide a source-controlled local development artifact that starts a DynamoDB-compatible persistence service for workstation use.
+- **FR-002**: Developers MUST be able to start the local persistence service without provisioning or modifying shared cloud resources.
+- **FR-003**: The feature MUST define the local connection details required for the application and local validation workflows to use the emulated persistence service.
+- **FR-004**: The local persistence service MUST support the application's required DynamoDB-dependent development and smoke-test workflows.
+- **FR-005**: The repository MUST document how to start, stop, verify, and troubleshoot the local persistence service.
+- **FR-006**: The local setup MUST identify which runtime values are configurable when a developer workstation has port conflicts, naming conflicts, or other local environment collisions.
+- **FR-007**: When the local persistence service is unavailable, unreachable, or fails to start, the feature MUST provide clear developer-facing guidance for diagnosing the problem.
+- **FR-008**: The local persistence environment MUST be reproducible across contributor workstations from the same repository state.
+- **FR-009**: Using the local persistence service MUST NOT require application source-code changes beyond normal environment-specific configuration.
+- **FR-010**: The feature MUST clearly scope the local persistence environment to development and local validation usage rather than production persistence.
+
+### Key Entities *(include if feature involves data)*
+
+- **Local Persistence Environment**: The reusable local setup artifact and runtime contract that provide a DynamoDB-compatible dependency on a developer workstation.
+- **Connection Contract**: The documented local settings a contributor uses to point the application or smoke-test workflow at the emulated persistence service.
+- **Developer Setup Guidance**: The repository-based instructions for starting, stopping, verifying, and troubleshooting the local persistence dependency.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On a workstation with the documented prerequisites already installed, a contributor can start and verify the local persistence service within 10 minutes of opening the repository.
+- **SC-002**: In smoke testing, 100% of representative DynamoDB-dependent local workflows defined for this feature complete successfully without using a live AWS account.
+- **SC-003**: A new contributor can locate the local persistence setup instructions and identify the required local connection details within 5 minutes.
+- **SC-004**: When startup fails because of missing prerequisites or local conflicts, contributors receive actionable troubleshooting guidance within the same setup flow in 100% of tested failure cases.
+- **SC-005**: Contributors can switch a local DynamoDB-dependent workflow to the emulated persistence service without modifying application source code in 100% of tested setup attempts.
+
+## Assumptions
+
+- The application already has or will have an environment-specific way to target a DynamoDB-compatible endpoint during local development.
+- Contributors using this feature have the required local container runtime or equivalent prerequisite installed before starting the local persistence environment.
+- Local emulation is intended for development and smoke testing, not for performance benchmarking or production parity guarantees.
+- Application-specific table creation, seed data, or reset behaviour remains the responsibility of existing startup or developer workflows unless separately specified.

--- a/specs/016-localstack-dynamodb-dockerfile/tasks.md
+++ b/specs/016-localstack-dynamodb-dockerfile/tasks.md
@@ -1,0 +1,198 @@
+# Tasks: Local DynamoDB Development Environment
+
+**Input**: Design documents from `/specs/016-localstack-dynamodb-dockerfile/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/local-dynamodb-runtime.md, quickstart.md
+
+**Tests**: Per constitution Principle I (TDD), tests are **REQUIRED** for this feature. Write the failing test coverage first in `tests/Payslip4All.Web.Tests` before changing implementation or documentation files.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and validated independently.
+
+## Format: `- [ ] T### [P?] [US#?] Description with file path`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare the shared failing-test surface and reusable local DynamoDB test scaffolding.
+
+- [X] T001 [P] Extend LocalStack image contract assertions in tests/Payslip4All.Web.Tests/Infrastructure/LocalStackIntegrationConfigTests.cs
+- [X] T002 [P] Extend local DynamoDB startup validation coverage in tests/Payslip4All.Web.Tests/Startup/DynamoDbConfigurationValidationTests.cs
+- [X] T003 [P] Refactor reusable local endpoint and table-prefix test helpers in tests/Payslip4All.Web.Tests/Integration/DynamoDbLocalStartupTests.cs
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Align the shared LocalStack runtime contract and DynamoDB startup plumbing before story work begins.
+
+**⚠️ CRITICAL**: Complete this phase before starting any user story.
+
+- [X] T004 [P] Align the pinned LocalStack runtime settings with the design contract in infra/localstack/Dockerfile
+- [X] T005 [P] Enforce the local runtime configuration and paired-credential contract in src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbConfigurationOptions.cs
+- [X] T006 [P] Preserve emulator-safe credential fallback for configured local endpoints in src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbClientFactory.cs
+- [X] T007 [P] Add actionable LocalStack readiness failures to src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbTableProvisioner.cs
+- [X] T008 Keep DynamoDB local startup registration aligned with the validated runtime contract in src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbServiceExtensions.cs
+
+**Checkpoint**: LocalStack contract, configuration validation, and startup plumbing are ready for story delivery.
+
+---
+
+## Phase 3: User Story 1 - Start a local persistence service (Priority: P1) 🎯 MVP
+
+**Goal**: Provide a reusable LocalStack artifact that starts a DynamoDB-compatible service on the documented local endpoint without live AWS dependencies.
+
+**Independent Test**: Build and run the container from `infra/localstack/Dockerfile`, then verify a DynamoDB-compatible service is reachable on `http://localhost:8000` using the documented workflow without a live AWS account.
+
+### Tests for User Story 1 (REQUIRED — TDD)
+
+- [X] T009 [P] [US1] Add Dockerfile runtime contract coverage in tests/Payslip4All.Web.Tests/Infrastructure/LocalStackIntegrationConfigTests.cs
+- [X] T010 [P] [US1] Add LocalStack build/run documentation contract coverage in tests/Payslip4All.Web.Tests/Infrastructure/LocalStackReadmeContractTests.cs
+
+### Implementation for User Story 1
+
+- [X] T011 [US1] Refine the LocalStack DynamoDB image contract in infra/localstack/Dockerfile
+- [X] T012 [US1] Document the LocalStack build, run, and verification flow in infra/localstack/README.md
+- [X] T013 [US1] Verify the build/run flow in specs/016-localstack-dynamodb-dockerfile/quickstart.md against infra/localstack/Dockerfile and infra/localstack/README.md
+
+**Checkpoint**: Contributors can build and start the LocalStack DynamoDB container consistently from the repository.
+
+---
+
+## Phase 4: User Story 2 - Use local DynamoDB-backed workflows (Priority: P2)
+
+**Goal**: Let the application and local smoke-test workflow use the emulated DynamoDB service through the existing DynamoDB provider contract.
+
+**Independent Test**: Start LocalStack, set the documented DynamoDB environment values, and verify representative DynamoDB-backed startup and repository workflows succeed against `http://localhost:8000`.
+
+### Tests for User Story 2 (REQUIRED — TDD)
+
+- [X] T014 [P] [US2] Extend local DynamoDB provisioning coverage in tests/Payslip4All.Web.Tests/Integration/DynamoDbLocalStartupTests.cs
+- [X] T015 [P] [US2] Add representative local repository workflow coverage in tests/Payslip4All.Web.Tests/Integration/DynamoDbLocalWorkflowTests.cs
+- [X] T016 [P] [US2] Add failing local configuration and unreachable-endpoint coverage in tests/Payslip4All.Web.Tests/Startup/DynamoDbConfigurationValidationTests.cs
+
+### Implementation for User Story 2
+
+- [X] T017 [US2] Clarify local region, endpoint, and credential validation errors in src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbConfigurationOptions.cs
+- [X] T018 [US2] Keep the documented local endpoint path source-code neutral in src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbClientFactory.cs and src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbServiceExtensions.cs
+- [X] T019 [US2] Improve LocalStack-unavailable guidance during startup provisioning in src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbTableProvisioner.cs
+- [X] T020 [US2] Verify the local integration workflow in tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj against specs/016-localstack-dynamodb-dockerfile/quickstart.md
+
+**Checkpoint**: The app and representative DynamoDB-backed workflows run successfully against the local emulator.
+
+---
+
+## Phase 5: User Story 3 - Reuse a standard team setup (Priority: P3)
+
+**Goal**: Make the LocalStack DynamoDB workflow discoverable, repeatable, and easy to troubleshoot for any contributor.
+
+**Independent Test**: A contributor unfamiliar with the setup can find the LocalStack instructions in the repository, start the service, configure the app, and follow the troubleshooting guidance without extra tribal knowledge.
+
+### Tests for User Story 3 (REQUIRED — TDD)
+
+- [X] T021 [P] [US3] Extend repository onboarding coverage for LocalStack discovery in tests/Payslip4All.Web.Tests/Infrastructure/LocalStackIntegrationConfigTests.cs
+- [X] T022 [P] [US3] Add LocalStack troubleshooting and configurability documentation coverage in tests/Payslip4All.Web.Tests/Infrastructure/LocalStackDocumentationContractTests.cs
+
+### Implementation for User Story 3
+
+- [X] T023 [P] [US3] Update repository entry-point guidance for local DynamoDB setup in README.md
+- [X] T024 [P] [US3] Expand start, stop, verify, configurable values, and troubleshooting guidance in infra/localstack/README.md
+- [X] T025 [US3] Validate the contributor walkthrough in README.md and infra/localstack/README.md against specs/016-localstack-dynamodb-dockerfile/quickstart.md
+
+**Checkpoint**: The LocalStack DynamoDB workflow is documented consistently for team reuse and onboarding.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Finish cross-story validation and consistency checks.
+
+- [ ] T026 [P] Run the LocalStack-focused test surface in tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj
+- [X] T027 [P] Tighten cross-file LocalStack troubleshooting and runtime wording in README.md, infra/localstack/README.md, and src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbConfigurationOptions.cs
+- [X] T028 Validate final build, run, runtime, and troubleshooting guidance against specs/016-localstack-dynamodb-dockerfile/contracts/local-dynamodb-runtime.md and specs/016-localstack-dynamodb-dockerfile/quickstart.md
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1: Setup** → no dependencies
+- **Phase 2: Foundational** → depends on Phase 1
+- **Phase 3: US1** → depends on Phase 2
+- **Phase 4: US2** → depends on Phase 3 because the local service must exist before app workflows can use it
+- **Phase 5: US3** → depends on Phase 4 so documentation reflects the working setup and failure guidance
+- **Phase 6: Polish** → depends on all completed story phases
+
+### User Story Dependencies
+
+- **US1**: first deliverable and MVP
+- **US2**: depends on US1
+- **US3**: depends on US1 and US2
+
+### Within Each User Story
+
+- Write tests first and confirm they fail before implementation.
+- Complete runtime/configuration changes before verification tasks.
+- Finish documentation changes only after the runtime behavior is working.
+- Present the Manual Test Gate before any commit, merge, or push.
+
+---
+
+## Parallel Opportunities
+
+- **Setup**: T001, T002, and T003 can run in parallel because they touch different test files.
+- **Foundational**: T004, T005, T006, and T007 can run in parallel before T008 syncs the shared registration path.
+- **US1**: T009 and T010 can run in parallel; after they fail, T011 and T012 can run in parallel.
+- **US2**: T014, T015, and T016 can run in parallel because they touch separate test files.
+- **US3**: T021 and T022 can run in parallel; after they fail, T023 and T024 can run in parallel.
+- **Polish**: T026 and T027 can run in parallel before T028 performs the final consistency check.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "Add Dockerfile runtime contract coverage in tests/Payslip4All.Web.Tests/Infrastructure/LocalStackIntegrationConfigTests.cs"
+Task: "Add LocalStack build/run documentation contract coverage in tests/Payslip4All.Web.Tests/Infrastructure/LocalStackReadmeContractTests.cs"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+Task: "Extend local DynamoDB provisioning coverage in tests/Payslip4All.Web.Tests/Integration/DynamoDbLocalStartupTests.cs"
+Task: "Add representative local repository workflow coverage in tests/Payslip4All.Web.Tests/Integration/DynamoDbLocalWorkflowTests.cs"
+Task: "Add failing local configuration and unreachable-endpoint coverage in tests/Payslip4All.Web.Tests/Startup/DynamoDbConfigurationValidationTests.cs"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+Task: "Update repository entry-point guidance for local DynamoDB setup in README.md"
+Task: "Expand start, stop, verify, configurable values, and troubleshooting guidance in infra/localstack/README.md"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1 and Phase 2.
+2. Deliver User Story 1 as the MVP.
+3. Verify the container build/run workflow from `infra/localstack/Dockerfile`.
+
+### Incremental Delivery
+
+1. Ship **US1** to establish the reusable local service.
+2. Ship **US2** to prove app and smoke-test workflows run against LocalStack.
+3. Ship **US3** to standardize team onboarding and troubleshooting.
+
+---
+
+## Notes
+
+- Task IDs run in dependency order from T001 to T028.
+- `[P]` is used only for tasks that can be executed in parallel without file conflicts.
+- User story labels appear only in user-story phases.
+- Every task includes at least one exact repository file path.
+- Manual Test Gate remains mandatory before any commit, merge, or push.

--- a/src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbClientFactory.cs
+++ b/src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbClientFactory.cs
@@ -25,14 +25,15 @@ public static class DynamoDbClientFactory
     public static IAmazonDynamoDB Create(DynamoDbConfigurationOptions options)
     {
         options.ValidateForStartup();
+        var endpointUri = options.GetValidatedEndpointUriOrNull();
 
         var config = new AmazonDynamoDBConfig
         {
             RegionEndpoint = RegionEndpoint.GetBySystemName(options.Region),
         };
 
-        if (!string.IsNullOrWhiteSpace(options.Endpoint))
-            config.ServiceURL = options.Endpoint;
+        if (endpointUri is not null)
+            config.ServiceURL = endpointUri.AbsoluteUri;
 
         if (options.HasExplicitCredentials)
         {
@@ -40,7 +41,7 @@ public static class DynamoDbClientFactory
             return new AmazonDynamoDBClient(credentials, config);
         }
 
-        if (!string.IsNullOrWhiteSpace(options.Endpoint))
+        if (endpointUri is not null)
         {
             // Local emulators commonly require syntactically valid credentials even though
             // they do not authenticate them, so use standard dummy values when no explicit

--- a/src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbConfigurationOptions.cs
+++ b/src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbConfigurationOptions.cs
@@ -35,12 +35,29 @@ public sealed class DynamoDbConfigurationOptions
             throw new InvalidOperationException(
                 $"PERSISTENCE_PROVIDER is set to 'dynamodb' but the required configuration value {Payslip4AllCustomConfigurationKeys.DynamoDb.Region} is not set.");
 
+        _ = GetValidatedEndpointUriOrNull();
+
         var hasAccessKey = !string.IsNullOrWhiteSpace(AccessKeyId);
         var hasSecretKey = !string.IsNullOrWhiteSpace(SecretAccessKey);
 
         if (hasAccessKey != hasSecretKey)
             throw new InvalidOperationException(
                 $"When using explicit DynamoDB credentials, both {Payslip4AllCustomConfigurationKeys.DynamoDb.AccessKeyId} and {Payslip4AllCustomConfigurationKeys.DynamoDb.SecretAccessKey} must be set.");
+    }
+
+    public Uri? GetValidatedEndpointUriOrNull()
+    {
+        if (string.IsNullOrWhiteSpace(Endpoint))
+            return null;
+
+        if (!Uri.TryCreate(Endpoint, UriKind.Absolute, out var endpointUri)
+            || (endpointUri.Scheme != Uri.UriSchemeHttp && endpointUri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new InvalidOperationException(
+                $"{Payslip4AllCustomConfigurationKeys.DynamoDb.Endpoint} must be an absolute http or https URL when configuring a local or custom DynamoDB endpoint.");
+        }
+
+        return endpointUri;
     }
 
     private static string? Normalize(string? value)

--- a/src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbServiceExtensions.cs
+++ b/src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbServiceExtensions.cs
@@ -19,8 +19,10 @@ public static class DynamoDbServiceExtensions
     /// </summary>
     public static IServiceCollection AddDynamoDbPersistence(this IServiceCollection services, DynamoDbConfigurationOptions options)
     {
+        options.ValidateForStartup();
+
         services.AddSingleton(options);
-        services.AddSingleton<DynamoDbTableNameProvider>();
+        services.AddSingleton(sp => new DynamoDbTableNameProvider(sp.GetRequiredService<DynamoDbConfigurationOptions>()));
         services.AddSingleton<IAmazonDynamoDB>(sp => DynamoDbClientFactory.Create(sp.GetRequiredService<DynamoDbConfigurationOptions>()));
 
         services.AddScoped<IUserRepository, DynamoDbUserRepository>();

--- a/src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbTableProvisioner.cs
+++ b/src/Payslip4All.Infrastructure/Persistence/DynamoDB/DynamoDbTableProvisioner.cs
@@ -1,5 +1,6 @@
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
+using Amazon.Runtime;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -19,19 +20,22 @@ public sealed class DynamoDbTableProvisioner : IHostedService
     private readonly DynamoDbTableNameProvider _tableNames;
     private readonly TimeSpan _activationTimeout;
     private readonly TimeSpan _pollInterval;
+    private readonly string? _configuredEndpoint;
 
     public DynamoDbTableProvisioner(
         IAmazonDynamoDB dynamoDb,
         ILogger<DynamoDbTableProvisioner> logger,
         DynamoDbTableNameProvider? tableNames = null,
         TimeSpan? activationTimeout = null,
-        TimeSpan? pollInterval = null)
+        TimeSpan? pollInterval = null,
+        DynamoDbConfigurationOptions? options = null)
     {
         _dynamoDb = dynamoDb;
         _logger = logger;
         _tableNames = tableNames ?? DynamoDbTableNameProvider.CreateDefault();
         _activationTimeout = activationTimeout ?? DefaultActivationTimeout;
         _pollInterval = pollInterval ?? DefaultPollInterval;
+        _configuredEndpoint = options?.GetValidatedEndpointUriOrNull()?.AbsoluteUri.TrimEnd('/');
     }
 
     public static IReadOnlyList<string> GetRequiredTableNames(string prefix)
@@ -94,6 +98,10 @@ public sealed class DynamoDbTableProvisioner : IHostedService
 
             await WaitForTableActiveAsync(request.TableName, cancellationToken);
         }
+        catch (AmazonServiceException ex)
+        {
+            throw CreateRuntimeUnavailableException(request.TableName, ex);
+        }
     }
 
     private async Task WaitForTableActiveAsync(string tableName, CancellationToken cancellationToken)
@@ -114,10 +122,13 @@ public sealed class DynamoDbTableProvisioner : IHostedService
             {
                 // Table creation is eventually consistent; keep polling until it becomes visible.
             }
+            catch (AmazonServiceException ex)
+            {
+                throw CreateRuntimeUnavailableException(tableName, ex);
+            }
 
             if (DateTimeOffset.UtcNow >= deadline)
-                throw new TimeoutException(
-                    $"Timed out waiting for DynamoDB table '{tableName}' to become ACTIVE.");
+                throw CreateActivationTimeoutException(tableName);
 
             await Task.Delay(_pollInterval, cancellationToken);
         }
@@ -431,5 +442,26 @@ public sealed class DynamoDbTableProvisioner : IHostedService
                 },
             },
         };
+    }
+
+    private InvalidOperationException CreateRuntimeUnavailableException(string tableName, Exception ex)
+    {
+        var guidance = _configuredEndpoint is null
+            ? "Check the configured AWS region and credential chain for the hosted DynamoDB path."
+            : $"Check that DYNAMODB_ENDPOINT points at a reachable LocalStack or emulator instance (current value: '{_configuredEndpoint}') and that the LocalStack container is running.";
+
+        return new InvalidOperationException(
+            $"Failed to reach DynamoDB while ensuring table '{tableName}'. {guidance}",
+            ex);
+    }
+
+    private TimeoutException CreateActivationTimeoutException(string tableName)
+    {
+        var guidance = _configuredEndpoint is null
+            ? "Check the configured AWS region, credentials, and table provisioning permissions."
+            : $"Check that DYNAMODB_ENDPOINT points at a healthy LocalStack or emulator instance (current value: '{_configuredEndpoint}') and that the LocalStack container finished starting.";
+
+        return new TimeoutException(
+            $"Timed out waiting for DynamoDB table '{tableName}' to become ACTIVE. {guidance}");
     }
 }

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,0 +1,1 @@
+dotnet test tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj --filter Category=Integration

--- a/tests/Payslip4All.Web.Tests/Infrastructure/LocalStackDocumentationContractTests.cs
+++ b/tests/Payslip4All.Web.Tests/Infrastructure/LocalStackDocumentationContractTests.cs
@@ -1,0 +1,46 @@
+namespace Payslip4All.Web.Tests.Infrastructure;
+
+public sealed class LocalStackDocumentationContractTests
+{
+    [Fact]
+    public void RepositoryAndLocalStackReadmes_StayAlignedOnTheSharedWorkflow()
+    {
+        var rootReadme = File.ReadAllText(Path.Combine(GetSolutionRoot(), "README.md"));
+        var localStackReadme = File.ReadAllText(Path.Combine(GetSolutionRoot(), "infra", "localstack", "README.md"));
+
+        const string buildCommand = "docker -H ssh://adhir-server build -f infra/localstack/Dockerfile -t payslip4all-localstack .";
+        const string runCommand = "docker -H ssh://adhir-server run --rm --name payslip4all-localstack -p 8000:8000 payslip4all-localstack";
+        const string integrationCommand = "dotnet test tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj --filter Category=Integration";
+
+        Assert.Contains(buildCommand, rootReadme, StringComparison.Ordinal);
+        Assert.Contains(buildCommand, localStackReadme, StringComparison.Ordinal);
+        Assert.Contains(runCommand, rootReadme, StringComparison.Ordinal);
+        Assert.Contains(runCommand, localStackReadme, StringComparison.Ordinal);
+        Assert.Contains(integrationCommand, rootReadme, StringComparison.Ordinal);
+        Assert.Contains(integrationCommand, localStackReadme, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RepositoryReadme_DocumentsDiscoveryConfigurabilityAndTroubleshooting()
+    {
+        var rootReadme = File.ReadAllText(Path.Combine(GetSolutionRoot(), "README.md"));
+
+        Assert.Contains("infra/localstack/README.md", rootReadme, StringComparison.Ordinal);
+        Assert.Contains("development and smoke testing", rootReadme, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("DYNAMODB_ENDPOINT=http://adhir-server:8000", rootReadme, StringComparison.Ordinal);
+        Assert.Contains("DYNAMODB_TABLE_PREFIX", rootReadme, StringComparison.Ordinal);
+        Assert.Contains("port `8000` is already in use", rootReadme, StringComparison.Ordinal);
+        Assert.Contains("dummy credentials", rootReadme, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetSolutionRoot()
+    {
+        var currentDir = Directory.GetCurrentDirectory();
+        while (currentDir is not null && !File.Exists(Path.Combine(currentDir, "Payslip4All.sln")))
+        {
+            currentDir = Directory.GetParent(currentDir)?.FullName;
+        }
+
+        return currentDir ?? throw new InvalidOperationException("Could not find solution root.");
+    }
+}

--- a/tests/Payslip4All.Web.Tests/Infrastructure/LocalStackIntegrationConfigTests.cs
+++ b/tests/Payslip4All.Web.Tests/Infrastructure/LocalStackIntegrationConfigTests.cs
@@ -1,0 +1,56 @@
+namespace Payslip4All.Web.Tests.Infrastructure;
+
+public sealed class LocalStackIntegrationConfigTests
+{
+    [Fact]
+    public void LocalStackDockerfile_PinsTheDynamoDbRuntimeContract()
+    {
+        var dockerfile = File.ReadAllText(Path.Combine(GetSolutionRoot(), "infra", "localstack", "Dockerfile"));
+
+        Assert.Contains("FROM localstack/localstack:3.5", dockerfile, StringComparison.Ordinal);
+        Assert.Contains("SERVICES=dynamodb", dockerfile, StringComparison.Ordinal);
+        Assert.Contains("GATEWAY_LISTEN=0.0.0.0:8000", dockerfile, StringComparison.Ordinal);
+        Assert.Contains("EDGE_PORT=8000", dockerfile, StringComparison.Ordinal);
+        Assert.Contains("AWS_DEFAULT_REGION=us-east-1", dockerfile, StringComparison.Ordinal);
+        Assert.Contains("EAGER_SERVICE_LOADING=1", dockerfile, StringComparison.Ordinal);
+        Assert.Contains("PERSISTENCE=0", dockerfile, StringComparison.Ordinal);
+        Assert.Contains("EXPOSE 8000", dockerfile, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RepositoryReadme_PointsContributorsToTheLocalStackWorkflow()
+    {
+        var rootReadme = File.ReadAllText(Path.Combine(GetSolutionRoot(), "README.md"));
+
+        Assert.Contains("LocalStack", rootReadme, StringComparison.Ordinal);
+        Assert.Contains("infra/localstack/Dockerfile", rootReadme, StringComparison.Ordinal);
+        Assert.Contains("infra/localstack/README.md", rootReadme, StringComparison.Ordinal);
+        Assert.Contains("PERSISTENCE_PROVIDER=dynamodb", rootReadme, StringComparison.Ordinal);
+        Assert.Contains("http://adhir-server:8000", rootReadme, StringComparison.Ordinal);
+        Assert.Contains("dummy credentials", rootReadme, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("development and smoke testing", rootReadme, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DynamoDbInfrastructureCode_KeepsTheLocalEndpointInDocumentationInsteadOfSource()
+    {
+        var clientFactory = File.ReadAllText(Path.Combine(GetSolutionRoot(), "src", "Payslip4All.Infrastructure", "Persistence", "DynamoDB", "DynamoDbClientFactory.cs"));
+        var serviceExtensions = File.ReadAllText(Path.Combine(GetSolutionRoot(), "src", "Payslip4All.Infrastructure", "Persistence", "DynamoDB", "DynamoDbServiceExtensions.cs"));
+        var configurationOptions = File.ReadAllText(Path.Combine(GetSolutionRoot(), "src", "Payslip4All.Infrastructure", "Persistence", "DynamoDB", "DynamoDbConfigurationOptions.cs"));
+
+        Assert.DoesNotContain("localhost:8000", clientFactory, StringComparison.Ordinal);
+        Assert.DoesNotContain("localhost:8000", serviceExtensions, StringComparison.Ordinal);
+        Assert.DoesNotContain("localhost:8000", configurationOptions, StringComparison.Ordinal);
+    }
+
+    private static string GetSolutionRoot()
+    {
+        var currentDir = Directory.GetCurrentDirectory();
+        while (currentDir is not null && !File.Exists(Path.Combine(currentDir, "Payslip4All.sln")))
+        {
+            currentDir = Directory.GetParent(currentDir)?.FullName;
+        }
+
+        return currentDir ?? throw new InvalidOperationException("Could not find solution root.");
+    }
+}

--- a/tests/Payslip4All.Web.Tests/Infrastructure/LocalStackReadmeContractTests.cs
+++ b/tests/Payslip4All.Web.Tests/Infrastructure/LocalStackReadmeContractTests.cs
@@ -1,0 +1,58 @@
+namespace Payslip4All.Web.Tests.Infrastructure;
+
+public sealed class LocalStackReadmeContractTests
+{
+    [Fact]
+    public void LocalStackReadme_DocumentsBuildRunVerifyAndStopFlow()
+    {
+        var readme = File.ReadAllText(Path.Combine(GetSolutionRoot(), "infra", "localstack", "README.md"));
+
+        Assert.Contains("docker -H ssh://adhir-server build -f infra/localstack/Dockerfile -t payslip4all-localstack .", readme, StringComparison.Ordinal);
+        Assert.Contains("docker -H ssh://adhir-server run --rm --name payslip4all-localstack -p 8000:8000 payslip4all-localstack", readme, StringComparison.Ordinal);
+        Assert.Contains("The container must remain running", readme, StringComparison.Ordinal);
+        Assert.Contains("dotnet test tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj --filter Category=Integration", readme, StringComparison.Ordinal);
+        Assert.Contains("docker -H ssh://adhir-server stop payslip4all-localstack", readme, StringComparison.Ordinal);
+
+        Assert.True(
+            readme.IndexOf("dotnet test tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj --filter Category=Integration", StringComparison.Ordinal)
+            < readme.IndexOf("docker -H ssh://adhir-server stop payslip4all-localstack", StringComparison.Ordinal),
+            "The README should document running the integration test before stopping the LocalStack container.");
+    }
+
+    [Fact]
+    public void LocalStackReadme_DocumentsRuntimeConfigurationAndCredentialExpectations()
+    {
+        var readme = File.ReadAllText(Path.Combine(GetSolutionRoot(), "infra", "localstack", "README.md"));
+
+        Assert.Contains("export PERSISTENCE_PROVIDER=dynamodb", readme, StringComparison.Ordinal);
+        Assert.Contains("export DYNAMODB_REGION=us-east-1", readme, StringComparison.Ordinal);
+        Assert.Contains("export DYNAMODB_ENDPOINT=http://adhir-server:8000", readme, StringComparison.Ordinal);
+        Assert.Contains("export DYNAMODB_TABLE_PREFIX=payslip4all", readme, StringComparison.Ordinal);
+        Assert.Contains("dummy credentials", readme, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("does not require a live AWS account", readme, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void LocalStackReadme_DocumentsConfigurableValuesAndTroubleshooting()
+    {
+        var readme = File.ReadAllText(Path.Combine(GetSolutionRoot(), "infra", "localstack", "README.md"));
+
+        Assert.Contains("port `8000` is already in use", readme, StringComparison.Ordinal);
+        Assert.Contains("choose a different host port", readme, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("DYNAMODB_ENDPOINT", readme, StringComparison.Ordinal);
+        Assert.Contains("DYNAMODB_TABLE_PREFIX", readme, StringComparison.Ordinal);
+        Assert.Contains("check that the container is still running", readme, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("paired explicit credentials", readme, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetSolutionRoot()
+    {
+        var currentDir = Directory.GetCurrentDirectory();
+        while (currentDir is not null && !File.Exists(Path.Combine(currentDir, "Payslip4All.sln")))
+        {
+            currentDir = Directory.GetParent(currentDir)?.FullName;
+        }
+
+        return currentDir ?? throw new InvalidOperationException("Could not find solution root.");
+    }
+}

--- a/tests/Payslip4All.Web.Tests/Integration/DynamoDbLocalStartupTests.cs
+++ b/tests/Payslip4All.Web.Tests/Integration/DynamoDbLocalStartupTests.cs
@@ -1,73 +1,19 @@
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
-using Payslip4All.Application.Interfaces.Repositories;
-using Payslip4All.Domain.Entities;
 using Payslip4All.Web.Tests.Startup;
 
 namespace Payslip4All.Web.Tests.Integration;
 
 [Trait("Category", "Integration")]
 [Collection(DynamoDbStartupTestCollection.Name)]
-public sealed class DynamoDbLocalStartupTests : IDisposable
+public sealed class DynamoDbLocalStartupTests
 {
-    private readonly Dictionary<string, string?> _savedEnv = new();
-
-    private static string GetTestEndpoint()
-        => Environment.GetEnvironmentVariable("DYNAMODB_ENDPOINT")?.Trim()
-           ?? "http://localhost:8000";
-
-    private static readonly string[] TableSuffixes =
-    {
-        "users",
-        "companies",
-        "employees",
-        "employee_loans",
-        "payslips",
-        "payslip_loan_deductions",
-        "wallets",
-        "wallet_activities",
-        "wallet_topup_attempts",
-        "payment_return_evidences",
-        "outcome_normalization_decisions",
-        "unmatched_payment_return_records"
-    };
-
-    private void SetEnv(string key, string? value)
-    {
-        _savedEnv.TryAdd(key, Environment.GetEnvironmentVariable(key));
-        Environment.SetEnvironmentVariable(key, value);
-    }
-
-    public void Dispose()
-    {
-        foreach (var (key, value) in _savedEnv)
-            Environment.SetEnvironmentVariable(key, value);
-    }
-
-    private static WebApplicationFactory<Program> BuildFactory()
-    {
-        return new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
-        {
-            builder.UseEnvironment("Development");
-            builder.UseSetting("PERSISTENCE_PROVIDER", "dynamodb");
-        });
-    }
-
     [Fact]
     public async Task CreateClient_WithLocalEndpoint_ProvisionsAllPrefixedTables()
     {
-        var prefix = $"webtest_{Guid.NewGuid():N}";
-        var endpoint = GetTestEndpoint();
-        SetEnv("DYNAMODB_REGION", "us-east-1");
-        SetEnv("DYNAMODB_ENDPOINT", endpoint);
-        SetEnv("DYNAMODB_TABLE_PREFIX", prefix);
-        SetEnv("AWS_ACCESS_KEY_ID", null);
-        SetEnv("AWS_SECRET_ACCESS_KEY", null);
-
-        await using var factory = BuildFactory();
+        using var harness = new LocalDynamoDbTestHarness();
+        await using var factory = harness.CreateFactory();
         _ = factory.CreateClient();
         await using var scope = factory.Services.CreateAsyncScope();
         var dynamoDb = scope.ServiceProvider.GetRequiredService<IAmazonDynamoDB>();
@@ -75,9 +21,9 @@ public sealed class DynamoDbLocalStartupTests : IDisposable
         try
         {
             var client = Assert.IsType<AmazonDynamoDBClient>(dynamoDb);
-            Assert.Equal($"{endpoint.TrimEnd('/')}/", client.Config.ServiceURL);
+            Assert.Equal(harness.NormalizedServiceUrl, client.Config.ServiceURL);
 
-            foreach (var tableName in GetExpectedTableNames(prefix))
+            foreach (var tableName in harness.ExpectedTableNames)
             {
                 var response = await dynamoDb.DescribeTableAsync(tableName);
                 Assert.Equal(TableStatus.ACTIVE, response.Table.TableStatus);
@@ -85,63 +31,15 @@ public sealed class DynamoDbLocalStartupTests : IDisposable
         }
         finally
         {
-            await DeleteProvisionedTablesAsync(dynamoDb, prefix);
-        }
-    }
-
-    [Fact]
-    public async Task CreateClient_WithLocalEndpoint_AllowsRepositoryCreateReadCycle()
-    {
-        var prefix = $"webtest_{Guid.NewGuid():N}";
-        var email = $"owner-{Guid.NewGuid():N}@example.com";
-        var endpoint = GetTestEndpoint();
-
-        SetEnv("DYNAMODB_REGION", "us-east-1");
-        SetEnv("DYNAMODB_ENDPOINT", endpoint);
-        SetEnv("DYNAMODB_TABLE_PREFIX", prefix);
-        SetEnv("AWS_ACCESS_KEY_ID", null);
-        SetEnv("AWS_SECRET_ACCESS_KEY", null);
-
-        await using var factory = BuildFactory();
-        _ = factory.CreateClient();
-        await using var scope = factory.Services.CreateAsyncScope();
-        var userRepository = scope.ServiceProvider.GetRequiredService<IUserRepository>();
-        var dynamoDb = scope.ServiceProvider.GetRequiredService<IAmazonDynamoDB>();
-
-        try
-        {
-            var user = new User
-            {
-                Email = email,
-                PasswordHash = "hash",
-            };
-
-            await userRepository.AddAsync(user);
-
-            var savedUser = await userRepository.GetByEmailAsync(email);
-
-            Assert.NotNull(savedUser);
-            Assert.Equal(user.Id, savedUser!.Id);
-            Assert.True(await userRepository.ExistsAsync(email));
-        }
-        finally
-        {
-            await DeleteProvisionedTablesAsync(dynamoDb, prefix);
+            await harness.DeleteProvisionedTablesAsync(dynamoDb);
         }
     }
 
     [Fact]
     public async Task CreateClient_WithLocalEndpoint_ExposesPayFastNotifyRoute()
     {
-        var prefix = $"webtest_{Guid.NewGuid():N}";
-        var endpoint = GetTestEndpoint();
-        SetEnv("DYNAMODB_REGION", "us-east-1");
-        SetEnv("DYNAMODB_ENDPOINT", endpoint);
-        SetEnv("DYNAMODB_TABLE_PREFIX", prefix);
-        SetEnv("AWS_ACCESS_KEY_ID", null);
-        SetEnv("AWS_SECRET_ACCESS_KEY", null);
-
-        await using var factory = BuildFactory();
+        using var harness = new LocalDynamoDbTestHarness();
+        await using var factory = harness.CreateFactory();
         using var client = factory.CreateClient();
 
         try
@@ -158,25 +56,7 @@ public sealed class DynamoDbLocalStartupTests : IDisposable
         {
             await using var scope = factory.Services.CreateAsyncScope();
             var dynamoDb = scope.ServiceProvider.GetRequiredService<IAmazonDynamoDB>();
-            await DeleteProvisionedTablesAsync(dynamoDb, prefix);
-        }
-    }
-
-    private static IEnumerable<string> GetExpectedTableNames(string prefix)
-        => TableSuffixes.Select(suffix => $"{prefix}_{suffix}");
-
-    private static async Task DeleteProvisionedTablesAsync(IAmazonDynamoDB dynamoDb, string prefix)
-    {
-        foreach (var tableName in GetExpectedTableNames(prefix))
-        {
-            try
-            {
-                await dynamoDb.DeleteTableAsync(tableName);
-            }
-            catch (ResourceNotFoundException)
-            {
-                // Table was never created or was already cleaned up.
-            }
+            await harness.DeleteProvisionedTablesAsync(dynamoDb);
         }
     }
 }

--- a/tests/Payslip4All.Web.Tests/Integration/DynamoDbLocalWorkflowTests.cs
+++ b/tests/Payslip4All.Web.Tests/Integration/DynamoDbLocalWorkflowTests.cs
@@ -1,0 +1,47 @@
+using Amazon.DynamoDBv2;
+using Microsoft.Extensions.DependencyInjection;
+using Payslip4All.Application.Interfaces.Repositories;
+using Payslip4All.Domain.Entities;
+using Payslip4All.Web.Tests.Startup;
+
+namespace Payslip4All.Web.Tests.Integration;
+
+[Trait("Category", "Integration")]
+[Collection(DynamoDbStartupTestCollection.Name)]
+public sealed class DynamoDbLocalWorkflowTests
+{
+    [Fact]
+    public async Task CreateClient_WithLocalEndpoint_AllowsRepresentativeUserRepositoryWorkflow()
+    {
+        using var harness = new LocalDynamoDbTestHarness();
+        var email = $"owner-{Guid.NewGuid():N}@example.com";
+
+        await using var factory = harness.CreateFactory();
+        _ = factory.CreateClient();
+        await using var scope = factory.Services.CreateAsyncScope();
+        var userRepository = scope.ServiceProvider.GetRequiredService<IUserRepository>();
+        var dynamoDb = scope.ServiceProvider.GetRequiredService<IAmazonDynamoDB>();
+
+        try
+        {
+            var user = new User
+            {
+                Email = email,
+                PasswordHash = "hash",
+            };
+
+            await userRepository.AddAsync(user);
+
+            var savedUser = await userRepository.GetByEmailAsync(email);
+
+            Assert.NotNull(savedUser);
+            Assert.Equal(user.Id, savedUser!.Id);
+            Assert.True(await userRepository.ExistsAsync(email));
+            Assert.Contains($"{harness.TablePrefix}_users", harness.ExpectedTableNames);
+        }
+        finally
+        {
+            await harness.DeleteProvisionedTablesAsync(dynamoDb);
+        }
+    }
+}

--- a/tests/Payslip4All.Web.Tests/Integration/LocalDynamoDbTestHarness.cs
+++ b/tests/Payslip4All.Web.Tests/Integration/LocalDynamoDbTestHarness.cs
@@ -1,0 +1,72 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Payslip4All.Infrastructure.Persistence.DynamoDB;
+
+namespace Payslip4All.Web.Tests.Integration;
+
+internal sealed class LocalDynamoDbTestHarness : IDisposable
+{
+    private readonly Dictionary<string, string?> _savedEnv = new();
+
+    public LocalDynamoDbTestHarness(string? tablePrefix = null, string? endpoint = null)
+    {
+        TablePrefix = tablePrefix ?? $"webtest_{Guid.NewGuid():N}";
+        Endpoint = endpoint?.Trim() ?? Environment.GetEnvironmentVariable("DYNAMODB_ENDPOINT")?.Trim() ?? "http://adhir-server:8000";
+
+        ConfigureEnvironment();
+    }
+
+    public string Endpoint { get; }
+    public string TablePrefix { get; }
+    public string NormalizedServiceUrl => Endpoint.EndsWith("/", StringComparison.Ordinal) ? Endpoint : $"{Endpoint}/";
+
+    public IReadOnlyList<string> ExpectedTableNames =>
+        new DynamoDbTableNameProvider(new DynamoDbConfigurationOptions { TablePrefix = TablePrefix }).GetRequiredTableNames();
+
+    public WebApplicationFactory<Program> CreateFactory()
+    {
+        return new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Development");
+            builder.UseSetting("PERSISTENCE_PROVIDER", "dynamodb");
+        });
+    }
+
+    public async Task DeleteProvisionedTablesAsync(IAmazonDynamoDB dynamoDb)
+    {
+        foreach (var tableName in ExpectedTableNames)
+        {
+            try
+            {
+                await dynamoDb.DeleteTableAsync(tableName);
+            }
+            catch (ResourceNotFoundException)
+            {
+                // Table was never created or was already cleaned up.
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var (key, value) in _savedEnv)
+            Environment.SetEnvironmentVariable(key, value);
+    }
+
+    private void ConfigureEnvironment()
+    {
+        SetEnv("DYNAMODB_REGION", "us-east-1");
+        SetEnv("DYNAMODB_ENDPOINT", Endpoint);
+        SetEnv("DYNAMODB_TABLE_PREFIX", TablePrefix);
+        SetEnv("AWS_ACCESS_KEY_ID", null);
+        SetEnv("AWS_SECRET_ACCESS_KEY", null);
+    }
+
+    private void SetEnv(string key, string? value)
+    {
+        _savedEnv.TryAdd(key, Environment.GetEnvironmentVariable(key));
+        Environment.SetEnvironmentVariable(key, value);
+    }
+}

--- a/tests/Payslip4All.Web.Tests/Startup/DynamoDbConfigurationValidationTests.cs
+++ b/tests/Payslip4All.Web.Tests/Startup/DynamoDbConfigurationValidationTests.cs
@@ -1,5 +1,6 @@
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
+using Amazon.Runtime;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
@@ -94,6 +95,42 @@ public sealed class DynamoDbConfigurationValidationTests : IDisposable
 
         Assert.Contains("AWS_ACCESS_KEY_ID", ex.Message);
         Assert.Contains("AWS_SECRET_ACCESS_KEY", ex.Message);
+    }
+
+    [Fact]
+    public void DynamoDbProvider_WithInvalidEndpointUri_ThrowsInvalidOperationException()
+    {
+        SetEnv("DYNAMODB_REGION", "us-east-1");
+        SetEnv("DYNAMODB_ENDPOINT", "not-a-valid-uri");
+        SetEnv("AWS_ACCESS_KEY_ID", null);
+        SetEnv("AWS_SECRET_ACCESS_KEY", null);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+        {
+            using var factory = BuildFactory();
+            _ = factory.Services;
+        });
+
+        Assert.Contains("DYNAMODB_ENDPOINT", ex.Message);
+        Assert.Contains("absolute http or https URL", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DynamoDbProvider_WithUnsupportedEndpointScheme_ThrowsInvalidOperationException()
+    {
+        SetEnv("DYNAMODB_REGION", "us-east-1");
+        SetEnv("DYNAMODB_ENDPOINT", "ftp://localhost:8000");
+        SetEnv("AWS_ACCESS_KEY_ID", null);
+        SetEnv("AWS_SECRET_ACCESS_KEY", null);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+        {
+            using var factory = BuildFactory();
+            _ = factory.Services;
+        });
+
+        Assert.Contains("DYNAMODB_ENDPOINT", ex.Message);
+        Assert.Contains("absolute http or https URL", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -193,20 +230,22 @@ public sealed class DynamoDbConfigurationValidationTests : IDisposable
     }
 
     [Fact]
-    public void DynamoDbProvider_WhenBootstrapHostedServiceFails_StartupFailsFast()
+    public void DynamoDbProvider_WhenLocalEndpointIsUnreachable_StartupFailsWithActionableGuidance()
     {
         SetEnv("DYNAMODB_REGION", "us-east-1");
         SetEnv("DYNAMODB_ENDPOINT", "http://localhost:8000");
         SetEnv("AWS_ACCESS_KEY_ID", null);
         SetEnv("AWS_SECRET_ACCESS_KEY", null);
 
-        var neverActive = new Mock<IAmazonDynamoDB>();
-        neverActive
+        var unreachable = new Mock<IAmazonDynamoDB>();
+        var connectivityFailure = new AmazonServiceException("Connection refused by local emulator");
+
+        unreachable
             .Setup(x => x.DescribeTableAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new ResourceNotFoundException("missing"));
-        neverActive
+            .ThrowsAsync(connectivityFailure);
+        unreachable
             .Setup(x => x.CreateTableAsync(It.IsAny<CreateTableRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new CreateTableResponse());
+            .ThrowsAsync(connectivityFailure);
 
         var ex = Assert.ThrowsAny<Exception>(() =>
         {
@@ -219,8 +258,8 @@ public sealed class DynamoDbConfigurationValidationTests : IDisposable
                     foreach (var descriptor in services.Where(d => d.ServiceType == typeof(IHostedService)).ToList())
                         services.Remove(descriptor);
                     foreach (var descriptor in services.Where(d => d.ServiceType == typeof(DynamoDbTableProvisioner)
-                                                                  || d.ServiceType == typeof(DynamoDbPaymentBootstrapHostedService)
-                                                                  || d.ServiceType == typeof(IAmazonDynamoDB)).ToList())
+                                                                   || d.ServiceType == typeof(DynamoDbPaymentBootstrapHostedService)
+                                                                   || d.ServiceType == typeof(IAmazonDynamoDB)).ToList())
                     {
                         services.Remove(descriptor);
                     }
@@ -234,13 +273,14 @@ public sealed class DynamoDbConfigurationValidationTests : IDisposable
 
                     services.AddSingleton(options);
                     services.AddSingleton(new DynamoDbTableNameProvider(options));
-                    services.AddSingleton(neverActive.Object);
+                    services.AddSingleton(unreachable.Object);
                     services.AddSingleton(new DynamoDbTableProvisioner(
-                        neverActive.Object,
+                        unreachable.Object,
                         NullLogger<DynamoDbTableProvisioner>.Instance,
                         new DynamoDbTableNameProvider(options),
                         activationTimeout: TimeSpan.Zero,
-                        pollInterval: TimeSpan.Zero));
+                        pollInterval: TimeSpan.Zero,
+                        options: options));
                     services.AddSingleton<DynamoDbPaymentBootstrapHostedService>();
                     services.AddHostedService(sp => sp.GetRequiredService<DynamoDbPaymentBootstrapHostedService>());
                 });
@@ -249,7 +289,8 @@ public sealed class DynamoDbConfigurationValidationTests : IDisposable
             _ = factory.CreateClient();
         });
 
-        Assert.Contains("ACTIVE", ex.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("DYNAMODB_ENDPOINT", ex.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("LocalStack", ex.ToString(), StringComparison.OrdinalIgnoreCase);
     }
 
     private static string WriteSecretsArtifact(IReadOnlyDictionary<string, string?> values)


### PR DESCRIPTION
## Summary\n- add and document the LocalStack DynamoDB workflow for Docker-over-SSH on adhir-server\n- update DynamoDB local configuration and integration test defaults to use adhir-server:8000\n- add feature specification, plan, tasks, and LocalStack documentation contract coverage\n\n## Testing\n- dotnet build Payslip4All.sln\n- dotnet test tests/Payslip4All.Web.Tests/Payslip4All.Web.Tests.csproj --filter "FullyQualifiedName~LocalStack"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * LocalStack-based local DynamoDB emulator now available for development, eliminating AWS account requirements during local testing.
  * Docker-based setup with automated container configuration and table provisioning.

* **Documentation**
  * Comprehensive guides added for running LocalStack locally, including configuration steps and troubleshooting.
  * New quickstart documentation for contributors.

* **Bug Fixes**
  * Improved error messages for DynamoDB connection failures with contextual guidance.
  * Enhanced endpoint URI validation for reliability.

* **Tests**
  * Integration tests added for local DynamoDB workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->